### PR TITLE
pref:ユーザーのいいね機能を修正（いいねの解除は出来ない仕様に変更）

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -13,13 +13,4 @@ class RelationshipsController < ApplicationController
       @user.update_attribute(:notification, true)
     end
   end
-
-  def destroy
-    @user = Relationship.find(params[:id]).followed
-    current_user.unfollow(@user)
-    respond_to do |format|
-      format.html { redirect_to @user }
-      format.js
-    end
-  end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -3,7 +3,8 @@ class RoomsController < ApplicationController
 
   def index
     get_followed_user_ids = Relationship.where(followed_id: current_user.id).pluck(:follower_id)
-    @match_users = Relationship.where(followed_id: get_followed_user_ids, follower_id: current_user.id).includes(:followed).sort_desc.map(&:followed)
+    get_match_user_ids = Relationship.where(followed_id: get_followed_user_ids, follower_id: current_user.id).pluck(:followed_id)
+    @match_users = User.includes(:passive_relationships).where(id: get_match_user_ids).order("relationships.created_at DESC").paginate(page: params[:page])
   end
 
   def create
@@ -20,7 +21,7 @@ class RoomsController < ApplicationController
   end
 
   def show
-    @room = Room.find_by(id: params[:id])
+    @room = Room.find(params[:id])
     @message_user = @room.entries.where.not(user_id: current_user.id).first.user
 
     @message = Message.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,14 +71,20 @@ class UsersController < ApplicationController
   def following
     @title = "フォロー"
     @user  = User.find(params[:id])
-    @users = @user.get_user_following
+
+    get_follower_user_ids = Relationship.where(follower_id: @user.id).pluck(:followed_id)
+    @users = User.includes(:passive_relationships).where(id: get_follower_user_ids).order("relationships.created_at DESC").paginate(page: params[:page])
+
     render 'show_follow'
   end
 
   def followers
     @title = "フォロワー"
     @user  = User.find(params[:id])
-    @users = @user.get_user_followers
+
+    get_followed_user_ids = Relationship.where(followed_id: @user.id).pluck(:follower_id)
+    @users = User.includes(:active_relationships).where(id: get_followed_user_ids).order("relationships.created_at DESC").paginate(page: params[:page])
+
     render 'show_follow'
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,6 @@
 class Notification < ApplicationRecord
   belongs_to :user
+  belongs_to :from_user, class_name: "User"
   belongs_to :datespot, optional: true
 
   scope :sort_desc, -> { order(created_at: :desc) }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,5 @@
 class Notification < ApplicationRecord
   belongs_to :user
-  belongs_to :from_user, class_name: "User"
   belongs_to :datespot, optional: true
 
   scope :sort_desc, -> { order(created_at: :desc) }

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -2,8 +2,6 @@ class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User", counter_cache: :followed_count
 
-  scope :sort_desc, -> { order(created_at: :desc) }
-
   validates :follower_id, presence: true
   validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :favorite_datespots, through: :favorites, source: :datespot
   has_many :comments, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :from_notifications, class_name: "Notification", foreign_key: :from_user_id, dependent: :destroy
   has_many :lists, dependent: :destroy
   has_many :browsing_histories, dependent: :destroy
   has_many :messages, dependent: :destroy
@@ -61,14 +62,6 @@ class User < ApplicationRecord
 
   def followed_by?(other_user)
     followers.include?(other_user)
-  end
-
-  def get_user_following
-    Relationship.where(follower_id: id).includes(:followed).order("created_at DESC").map(&:followed)
-  end
-
-  def get_user_followers
-    Relationship.where(followed_id: id).includes(:follower).order("created_at DESC").map(&:follower)
   end
 
   def favorite(datespot)

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,2 +1,2 @@
-$("#follow_form").html("<%= escape_javascript(render('users/unfollow')) %>");
+$("#follow_form").html("<%= escape_javascript(render('users/follow_form')) %>");
 $("#followers").html('<%= @user.followers.count %>');

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,2 +1,0 @@
-$("#follow_form").html("<%= escape_javascript(render('users/follow')) %>");
-$("#followers").html('<%= @user.followers.count %>');

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,4 +1,4 @@
 <%= form_for(current_user.active_relationships.build, remote: true) do |f| %>
   <div><%= hidden_field_tag :followed_id, @user.id %></div>
-  <%= f.submit "いいねをする", class: "btn btn-primary" %>
+  <%= f.submit "いいね！", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,7 +1,7 @@
 <% unless current_user?(@user) %>
   <div id="follow_form">
   <% if current_user.following?(@user) %>
-    <%= render 'unfollow' %>
+    <%= link_to "いいね済", "#", class: "btn btn-primary" %>
   <% else %>
     <%= render 'follow' %>
   <% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,5 +1,0 @@
-<%= form_for(current_user.active_relationships.find_by(followed_id: @user.id),
-             html: { method: :delete },
-             remote: true) do |f| %>
-  <%= f.submit "いいねをやめる", class: "btn" %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :destroy]
   end
 
-  resources :relationships, only: [:create, :destroy]
+  resources :relationships, only: [:create]
 
   get :favorites, to: 'favorites#index'
   post   "favorites/:datespot_id/create"  => "favorites#create"

--- a/spec/requests/relationship_spec.rb
+++ b/spec/requests/relationship_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "ユーザーフォロー機能", type: :request do
+RSpec.describe "ユーザーのいいね！機能", type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
 
@@ -9,32 +9,16 @@ RSpec.describe "ユーザーフォロー機能", type: :request do
       login_for_request(user)
     end
 
-    it "ユーザーのフォローができること" do
+    it "ユーザーをいいね！できること" do
       expect {
         post relationships_path, params: { followed_id: other_user.id }
       }.to change(user.following, :count).by(1)
     end
 
-    it "ユーザーのAjaxによるフォローができること" do
+    it "ユーザーのAjaxによるいいね！ができること" do
       expect {
         post relationships_path, xhr: true, params: { followed_id: other_user.id }
       }.to change(user.following, :count).by(1)
-    end
-
-    it "ユーザーのアンフォローができること" do
-      user.follow(other_user)
-      relationship = user.active_relationships.find_by(followed_id: other_user.id)
-      expect {
-        delete relationship_path(relationship)
-      }.to change(user.following, :count).by(-1)
-    end
-
-    it "ユーザーのAjaxによるアンフォローができること" do
-      user.follow(other_user)
-      relationship = user.active_relationships.find_by(followed_id: other_user.id)
-      expect {
-        delete relationship_path(relationship), xhr: true
-      }.to change(user.following, :count).by(-1)
     end
   end
 
@@ -52,13 +36,6 @@ RSpec.describe "ユーザーフォロー機能", type: :request do
     it "createアクションは実行できず、ログインページへリダイレクトすること" do
       expect {
         post relationships_path
-      }.not_to change(Relationship, :count)
-      expect(response).to redirect_to login_path
-    end
-
-    it "destroyアクションは実行できず、ログインページへリダイレクトすること" do
-      expect {
-        delete relationship_path(user)
       }.not_to change(Relationship, :count)
       expect(response).to redirect_to login_path
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -125,14 +125,12 @@ RSpec.describe "Users", type: :system do
       end
     end
 
-    context "ユーザーのフォロー/アンフォロー処理", js: true do
-      it "ユーザーのフォロー/アンフォローができること" do
+    context "ユーザーをいいね！する", js: true do
+      it "ユーザーをいいね！できること" do
         visit user_path(other_user)
-        expect(page).to have_button 'いいねをする'
-        click_button 'いいねをする'
-        expect(page).to have_button 'いいねをやめる'
-        click_button 'いいねをやめる'
-        expect(page).to have_button 'いいねをする'
+        expect(page).to have_button 'いいね！'
+        click_button 'いいね！'
+        expect(page).to have_content 'いいね済'
       end
     end
 


### PR DESCRIPTION
Closes #109 

### 【概要】
・いいねをしたらいいねの取り消しは出来ない仕様に変更
・ユーザーのいいね機能の仕様変更による各種テストの修正

### 【修正内容の検証方法】
`bin/rspec`
`bundle exec rubocop`

### 【この修正が正しい理由】
・テストが正常に完了する(199 examples, 0 failures)
・rubocopが正常に完了する(88 files inspected, no offenses detected)