### PR TITLE
fix:デプロイ中に発生した「Missing for 'production' environment」というエラーの修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,6 +29,8 @@ set :rbenv_ruby, '2.5.7'
 set :ssh_options, auth_methods: ['publickey'],
                   keys: ['~/.ssh/date-match.pem']
 
+set :linked_files, %w{config/master.key}
+
 #出力するログのレベル
 set :log_level, :debug
 


### PR DESCRIPTION
Closes #119 

### 【概要】
・「Missing for 'production' environment」というエラーを解決するためにconfig/deploy/rbへset :linked_files, %w{config/master.key}を追加

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(199 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)