### PR TITLE
fix:デプロイ中に発生した「could not translate host name db to address」というエラーの修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,3 +82,7 @@ test:
 #
 production:
   <<: *default
+  database: <%= ENV['DB_NAME'] %>
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  host: <%= ENV['DB_HOSTNAME'] %>


### PR DESCRIPTION
Closes #123 

### 【概要】
・「could not translate host name db to address」というエラーを解決するためにconfig/database.ymlのproductionを修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(199 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)