### PR TITLE
feat:CircleCIによるCD機能の実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,4 +69,8 @@ jobs:
 
       - deploy:
           name: Capistrano deploy
-          command: bundle exec cap production deploy
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "master" ]; then
+              exit 0
+            fi
+            bundle exec cap production deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "47:ea:8d:a1:7f:c7:0e:94:cb:79:9d:cc:76:c6:c0:03"
+            - "89:6e:20:9e:68:14:d2:07:28:28:f5:10:fa:6a:00:97"
 
       - deploy:
           name: Capistrano deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,7 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+      - add_ssh_keys:
+          fingerprints:
+            - "47:ea:8d:a1:7f:c7:0e:94:cb:79:9d:cc:76:c6:c0:03"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "47:ea:8d:a1:7f:c7:0e:94:cb:79:9d:cc:76:c6:c0:03"
+
+      - deploy:
+          name: Capistrano deploy
+          command: bundle exec cap production deploy

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,6 +16,8 @@ set :deploy_to, '/var/www/rails/datelog'
 # シンボリックリンクをはるファイル
 set :linked_files, fetch(:linked_files, []).push('config/settings.yml')
 
+set :linked_files, %w(config/master.key .env)
+
 # シンボリックリンクをはるフォルダ
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system')
 
@@ -24,12 +26,6 @@ set :keep_releases, 5
 
 # rubyのバージョン
 set :rbenv_ruby, '2.5.7'
-
-# どの公開鍵を利用してデプロイするか
-set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/date-match.pem']
-
-set :linked_files, %w{config/master.key}
 
 #出力するログのレベル
 set :log_level, :debug

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,9 +1,6 @@
 # EC2サーバーのIP、EC2サーバーにログインするユーザー名、サーバーのロールを記述
 server '52.197.170.143', user: 'keita', roles: %w{app db web}
 
-# CircleCIのGUIで設定した環境変数を使ってSSH接続
-set :ssh_options, {
-  keys: [ENV.fetch('PRODUCTION_SSH_KEY').to_s],
-  forward_agent: true,
-  auth_methods: %w[publickey]
-}
+set :ssh_options, auth_methods: ['publickey'],
+                  keys: ["~/.ssh/date-match_rsa_896e209e6814d2072828f510fa6a0097"],
+                  forward_agent: true

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,2 +1,9 @@
 # EC2サーバーのIP、EC2サーバーにログインするユーザー名、サーバーのロールを記述
 server '52.197.170.143', user: 'keita', roles: %w{app db web}
+
+# CircleCIのGUIで設定した環境変数を使ってSSH接続
+set :ssh_options, {
+  keys: [ENV.fetch('PRODUCTION_SSH_KEY').to_s],
+  forward_agent: true,
+  auth_methods: %w[publickey]
+}


### PR DESCRIPTION
Closes #129 

### 【概要】
・.circleci/config.ymlにEC2インスタンスへアクセスするためのsshキーを追加
・.circleci/config.ymlにcapistranoによるデプロイを行うコードを追加
・config/deploy/production.rbにssh接続するコードを追加
・sshキーをssh-keygen -m pemで再作成してPEM形式の秘密鍵を使ったSSH通信へ修正
・masterブランチにマージした時のみcapistranoデプロイが実行される設定を追加

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(199 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)