### PR TITLE
fix:デプロイ中に発生した「To use ES6 syntax, harmony mode must be enabled with Uglifier」というエラーの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Closes #137 

### 【概要】
・「To use ES6 syntax, harmony mode must be enabled with Uglifier」というエラーを解決するためにconfig/environments/production.rbを修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(191 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)