### PR TITLE
feat:いいね！一覧ページのデザインを修正

### DIFF
--- a/app/controllers/datespots_controller.rb
+++ b/app/controllers/datespots_controller.rb
@@ -33,16 +33,16 @@ class DatespotsController < ApplicationController
   def index
     if params[:q].present?
       @search = Datespot.ransack(params[:q])
-      @datespots = @search.result.with_attached_images.includes(:user, :taggings, :comments).paginate(page: params[:page], per_page: 9)
+      @datespots = @search.result.with_attached_images.includes(:user, :taggings, :comments).paginate(page: params[:page], per_page: 15)
       if params[:tag_name]
-        @datespots = @search.result.tagged_with("#{params[:tag_name]}").with_attached_images.includes(:user, :taggings).paginate(page: params[:page], per_page: 9)
+        @datespots = @search.result.tagged_with("#{params[:tag_name]}").with_attached_images.includes(:user, :taggings).paginate(page: params[:page], per_page: 15)
       end
     else
       params[:q] = { sorts: 'updated_at desc' }
       @search = Datespot.ransack(params[:q])
-      @datespots = @search.result.with_attached_images.includes(:user, :taggings, :comments).paginate(page: params[:page], per_page: 9)
+      @datespots = @search.result.with_attached_images.includes(:user, :taggings, :comments).paginate(page: params[:page], per_page: 15)
       if params[:tag_name]
-        @datespots = @search.result.tagged_with("#{params[:tag_name]}").with_attached_images.includes(:user, :taggings).paginate(page: params[:page], per_page: 9)
+        @datespots = @search.result.tagged_with("#{params[:tag_name]}").with_attached_images.includes(:user, :taggings).paginate(page: params[:page], per_page: 15)
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,17 +10,17 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @datespots = @user.datespots.includes(:taggings, :comments, images_attachments: :blob, user: { avatars_attachments: :blob }).paginate(page: params[:page], per_page: 10).sort_desc
+    @datespots = @user.datespots.includes(:taggings, :comments, images_attachments: :blob, user: { avatars_attachments: :blob }).paginate(page: params[:page], per_page: 15).sort_desc
   end
 
   def index
     if params[:q].present?
       @search = User.ransack(params[:q])
-      @users = @search.result.with_attached_avatars.paginate(page: params[:page])
+      @users = @search.result.with_attached_avatars.paginate(page: params[:page], per_page: 15)
     else
       params[:q] = { sorts: 'updated_at desc' }
       @search = User.ransack(params[:q])
-      @users = @search.result.with_attached_avatars.paginate(page: params[:page])
+      @users = @search.result.with_attached_avatars.paginate(page: params[:page], per_page: 15)
     end
   end
 
@@ -70,21 +70,21 @@ class UsersController < ApplicationController
   end
 
   def following
-    @title = "フォロー"
+    @title = "いいね！一覧(自分から)"
     @user  = User.find(params[:id])
 
     get_follower_user_ids = Relationship.where(follower_id: @user.id).pluck(:followed_id)
-    @users = User.includes(:passive_relationships).where(id: get_follower_user_ids).order("relationships.created_at DESC").paginate(page: params[:page])
+    @users = User.includes(:passive_relationships).where(id: get_follower_user_ids).order("relationships.created_at DESC").paginate(page: params[:page], per_page: 15)
 
     render 'show_follow'
   end
 
   def followers
-    @title = "フォロワー"
+    @title = "いいね！一覧(相手から)"
     @user  = User.find(params[:id])
 
     get_followed_user_ids = Relationship.where(followed_id: @user.id).pluck(:follower_id)
-    @users = User.includes(:active_relationships).where(id: get_followed_user_ids).order("relationships.created_at DESC").paginate(page: params[:page])
+    @users = User.includes(:active_relationships).where(id: get_followed_user_ids).order("relationships.created_at DESC").paginate(page: params[:page], per_page: 15)
 
     render 'show_follow'
   end

--- a/app/views/users/_user_index_info.html.erb
+++ b/app/views/users/_user_index_info.html.erb
@@ -16,10 +16,16 @@
       <% end %>
     </div>
   </div>
-  <span class="user-index-info__residence"><i class="fas fa-map-marker-alt fa-lg user-index-info__icon"></i><%= @user.prefecture.name %></span><br>
-  <span class="user-index-info__age"><i class="fas fa-calendar user-index-info__icon"></i><%= @user.age_i18n %></span><br>
+  <% if @user.prefecture.present? %>
+    <span class="user-index-info__residence"><i class="fas fa-map-marker-alt fa-lg user-index-info__icon"></i><%= @user.prefecture.name %></span><br>
+  <% end %>
+  <% if @user.age.present? %>
+    <span class="user-index-info__age"><i class="fas fa-calendar user-index-info__icon"></i><%= @user.age_i18n %></span><br>
+  <% end %>
   <span class="user-index-info__sex"><i class="fas fa-venus-mars user-index-info__icon"></i><%= @user.sex_i18n %></span><br>
+  <% if @user.introduction.present? %>
     <span class="user-index-info__introduction"><i class="fas fa-comment-dots user-index-info__icon"></i><%= @user.introduction %></span><br>
+  <% end %>
   <div class="user-index-info__bottom">
     <span class="user-index-info__bottom--timestamp">
       <%= l @user.updated_at %>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,26 +1,23 @@
 <% provide(:title, @title) %>
-<div class="row">
-  <aside class="col-md-4">
-    <section class="user_info">
-      <% if @user.avatars.attached? %>
-        <div class="swiper-slide"><%= image_tag @user.avatars.first.variant(resize:'400x400').processed %></div>
-      <% else %>
-        <%= image_tag 'thumb400_default.png'%>
-      <% end %>
-      <h1><%= @user.name %></h1>
-      <span><%= link_to "プロフィール", @user %></span>
-      <span>【投稿数】 <%= @user.datespots_count %> 件</span>
-    </section>
-    <section class="stats">
-      <%= render 'shared/stats' %>
-    </section>
-  </aside>
-  <div class="col-md-8">
-    <h3><%= @title %></h3>
-    <% if @users.any? %>
-      <ul class="users follow">
-        <%= render @users %>
-      </ul>
-    <% end %>
+<div class="container-fluid">
+  <div class="row">
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <%= render 'shared/flash_messages' %>
+        <h1 class="heading__title"><%= @title %></h1>
+      </div>
+      <div class="content">
+        <% if @users.any? %>
+          <ol class="user-index">
+            <%= render @users %>
+          </ol>
+          <%= will_paginate @users, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
+        <% else %>
+          ユーザーは存在しません
+        <% end %>
+      </div>
+      <%= render 'layouts/footer' %>
+    </div>
   </div>
 </div>

--- a/spec/system/relationship_spec.rb
+++ b/spec/system/relationship_spec.rb
@@ -12,24 +12,16 @@ RSpec.describe "Relationships", type: :system do
     end
 
     context "ページレイアウト" do
-      it "「フォロー」の文字列が存在すること" do
-        expect(page).to have_content 'フォロー'
+      it "「いいね！一覧(自分から)」の文字列が存在すること" do
+        expect(page).to have_content 'いいね！一覧(自分から)'
       end
 
       it "正しいタイトルが表示されること" do
-        expect(page).to have_title full_title('フォロー')
+        expect(page).to have_title full_title('いいね！一覧(自分から)')
       end
 
-      it "ユーザー情報が表示されていること" do
-        expect(page).to have_content user.name
-        expect(page).to have_link "プロフィール", href: user_path(user)
-        expect(page).to have_content "【投稿数】 #{user.datespots_count} 件"
-        expect(page).to have_link "#{user.following.count}人にいいねをしました", href: following_user_path(user)
-        expect(page).to have_link "#{user.followers.count}人にいいねをされました", href: followers_user_path(user)
-      end
-
-      it "フォロー中のユーザーが表示されていること" do
-        within find('.users') do
+      it "いいね！一覧(自分から)が表示されていること" do
+        within find('.user-index__card') do
           user.following.each do |u|
             expect(page).to have_link u.name, href: user_path(u)
           end
@@ -46,24 +38,16 @@ RSpec.describe "Relationships", type: :system do
     end
 
     context "ページレイアウト" do
-      it "「フォロワー」の文字列が存在すること" do
-        expect(page).to have_content 'フォロワー'
+      it "「いいね！一覧(相手から)」の文字列が存在すること" do
+        expect(page).to have_content 'いいね！一覧(相手から)'
       end
 
       it "正しいタイトルが表示されること" do
-        expect(page).to have_title full_title('フォロワー')
+        expect(page).to have_title full_title('いいね！一覧(相手から)')
       end
 
-      it "ユーザー情報が表示されていること" do
-        expect(page).to have_content user.name
-        expect(page).to have_link "プロフィール", href: user_path(user)
-        expect(page).to have_content "【投稿数】 #{user.datespots_count} 件"
-        expect(page).to have_link "#{user.following.count}人にいいねをしました", href: following_user_path(user)
-        expect(page).to have_link "#{user.followers.count}人にいいねをされました", href: followers_user_path(user)
-      end
-
-      it "フォロワーが表示されていること" do
-        within find('.users') do
+      it "いいね！一覧(相手から)が表示されていること" do
+        within find('.user-index__card') do
           user.followers.each do |u|
             expect(page).to have_link u.name, href: user_path(u)
           end


### PR DESCRIPTION
Closes #151 

### 【概要】
・いいね！一覧ページのレイアウトを変更
・いいね！一覧ページのデザイン修正に伴うテストの修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(186 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)