### PR TITLE
pref:いいね！一覧ページの仕様変更

### DIFF
--- a/app/assets/stylesheets/Object/Project/user-index-info.scss
+++ b/app/assets/stylesheets/Object/Project/user-index-info.scss
@@ -47,7 +47,7 @@
       justify-content: flex-end;
       font-size: 1.6rem;
 
-      &-impressions, &-datespots, &-followed {
+      &-impressions, &-followed, &-datespots {
         display:flex;
         margin-left: 10%;
       }

--- a/app/assets/stylesheets/Object/Project/user-show-info.scss
+++ b/app/assets/stylesheets/Object/Project/user-show-info.scss
@@ -28,13 +28,18 @@
       font-size: 1.8rem;
       margin-bottom: 1.5%;
 
-      &-count {
+      &-count-link {
         padding-right: 5%;
         color: $link-color__blue;
       }
 
+      &-count {
+        padding-right: 5%;
+        color: $font-color__wine-red;
+      }
+
       i {
-        padding-right: 3.7%;
+        padding-right: 3.5%;
       }
     }
 

--- a/app/views/layouts/_logging_in_sidebar.html.erb
+++ b/app/views/layouts/_logging_in_sidebar.html.erb
@@ -1,4 +1,3 @@
-<% @user ||= current_user %>
 <div class="sidebar logging-in-sidebar">
   <%= link_to(image_tag("logo.png", :width => "100%", :height => "auto", :alt => "date-matchのロゴ"), datespots_path,) %>
   <nav class="sidebar__nav logging-in-sidebar__nav">
@@ -8,7 +7,7 @@
       <li class="logging-in-sidebar__nav--item"><%= link_to favorites_path, class: "logging-in-sidebar__nav--item-link" do %><i class="fa fa-heart logging-in-sidebar__nav--item-icon"></i>お気に入り<% end %></li>
       <li class="logging-in-sidebar__nav--item"><%= link_to browsing_histories_path, class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-eye logging-in-sidebar__nav--item-icon"></i>閲覧履歴<% end %></li>
       <li class="logging-in-sidebar__nav--item"><%= link_to users_path, class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-users logging-in-sidebar__nav--item-icon"></i>ユーザーを探す<% end %></li>
-      <li class="logging-in-sidebar__nav--item"><%= link_to followers_user_path(@user), class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-thumbs-up logging-in-sidebar__nav--item-icon"></i>お相手から<% end %></li>
+      <li class="logging-in-sidebar__nav--item"><%= link_to followers_user_path(current_user), class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-thumbs-up logging-in-sidebar__nav--item-icon"></i>お相手から<% end %></li>
       <li class="logging-in-sidebar__nav--item"><%= link_to rooms_path, class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-comments logging-in-sidebar__nav--item-icon"></i>メッセージ<% end %></li>
       <li class="logging-in-sidebar__nav--item"><%= link_to current_user, class: "logging-in-sidebar__nav--item-link" do %><i class="zmdi zmdi-account-box zmdi-hc-lg logging-in-sidebar__nav--item-icon"></i>プロフィール<% end %></li>
       <li class="logging-in-sidebar__nav--item"><%= link_to notifications_path, class: "logging-in-sidebar__nav--item-link" do %><i class="fas fa-bell logging-in-sidebar__nav--item-icon"></i>通知一覧<% end %></li>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,11 +1,15 @@
 <% @user ||= current_user %>
 <div>
-  <a href="<%= followers_user_path(@user) %>">
+  <% if current_user?(@user) %>
+    <a href="<%= followers_user_path(@user) %>">
+      <span id="followers" class="user-show-info__status--stats-count-link"><i class="fas fa-thumbs-up"></i><%= @user.followed_count %>人にいいねされました</span>
+    </a>
+  <% else %>
     <span id="followers" class="user-show-info__status--stats-count"><i class="fas fa-thumbs-up"></i><%= @user.followed_count %>人にいいねされました</span>
-  </a>
+  <% end %>
   <% if current_user?(@user) %>
     <a href="<%= following_user_path(@user) %>">
-      <span id="following" class="user-show-info__status--stats-count"><i class="far fa-thumbs-up"></i><%= @user.following.count %>人にいいねしました</span>
+      <span id="following" class="user-show-info__status--stats-count-link"><i class="far fa-thumbs-up"></i><%= @user.following.count %>人にいいねしました</span>
     </a>　
   <% end %>
 </div>

--- a/app/views/users/_user_index_info.html.erb
+++ b/app/views/users/_user_index_info.html.erb
@@ -34,11 +34,11 @@
       <span class="user-index-info__bottom--actions-impressions">
         <i class="fas fa-shoe-prints"></i>&nbsp;<%= @user.impressions_count %>
       </span>
-      <span class="user-index-info__bottom--actions-datespots">
-        <i class="zmdi zmdi-male-female zmdi-hc-lg"></i>&nbsp;<%= @user.datespots_count %>
-      </span>
       <span class="user-index-info__bottom--actions-followed">
         <i class="fas fa-thumbs-up"></i><span id="followers">&nbsp;<%= @user.followed_count %></span>
+      </span>
+      <span class="user-index-info__bottom--actions-datespots">
+        <i class="zmdi zmdi-male-female zmdi-hc-lg"></i>&nbsp;<%= @user.datespots_count %>
       </span>
     </div>
   </div>

--- a/app/views/users/_user_show_info.html.erb
+++ b/app/views/users/_user_show_info.html.erb
@@ -47,7 +47,7 @@
     </div>
   </div>
   <div class="user-show-info__datespots">
-    <span class="user-show-info__datespots--title">自分の提案一覧(<%= @user.datespots.count %>件)</span>
+    <span class="user-show-info__datespots--title">提案一覧(<%= @user.datespots.count %>件)</span>
     <div class="user-show-info__datespots--content">
       <% if @user.datespots.any? %>
         <ol class="datespot-index">

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Users", type: :system do
       end
 
       it "デートスポットの件数が表示されていることを確認" do
-        expect(page).to have_content "自分の提案一覧(#{user.datespots.count}件)"
+        expect(page).to have_content "提案一覧(#{user.datespots.count}件)"
       end
 
       it "デートスポットの情報が表示されていることを確認" do


### PR DESCRIPTION
Closes #159 

### 【概要】
・いいね！一覧ページはログインユーザーのページのみ表示する仕様へ変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)