### PR TITLE
feat:投稿・ユーザー編集ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/comment-index.scss
+++ b/app/assets/stylesheets/Object/Project/comment-index.scss
@@ -19,8 +19,13 @@
     &--comments-more {
       position: relative;
       display: inline-block;
+      color: $link-color__blue;
       font-size: 1.3rem;
       cursor: pointer;
+
+      i {
+        color: $link-color__blue;
+      }
     }
 
     &--comments-more::after {
@@ -30,7 +35,7 @@
       bottom: -3px;
       left: 0;
       content: '';
-      background: $font-color__wine-red;
+      background: $link-color__blue;
       @include ProprtySetPrefix(transform, scale(0, 1));
       transform-origin: center top;
       transition: transform 0.3s;

--- a/app/assets/stylesheets/Object/Project/datespot-edit.scss
+++ b/app/assets/stylesheets/Object/Project/datespot-edit.scss
@@ -1,0 +1,22 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.datespot-edit {
+  margin-bottom: 3%;
+
+  &__description-title {
+    font-size: 2.4rem;
+  }
+
+  &__description-attention {
+    font-size: 1.6rem;
+  }
+
+  &__description-no-image {
+    font-size: 2rem;
+  }
+
+  &__image {
+    margin-bottom: 2%;
+  }
+}

--- a/app/assets/stylesheets/Object/Project/info-form.scss
+++ b/app/assets/stylesheets/Object/Project/info-form.scss
@@ -62,9 +62,14 @@
   &__map {
     position: relative;
     display: inline-block;
+    color: $link-color__blue;
     font-size: 1.4rem;
     cursor: pointer;
     margin-left: 1%;
+
+    i {
+      color: $link-color__blue;
+    }
   }
 
   &__map::after {
@@ -74,7 +79,7 @@
     bottom: -3px;
     left: 0;
     content: '';
-    background: $font-color__wine-red;
+    background: $link-color__blue;
     @include ProprtySetPrefix(transform, scale(0, 1));
     transform-origin: center top;
     transition: transform 0.3s;
@@ -84,7 +89,7 @@
     @include ProprtySetPrefix(transform, scale(1, 1));
   }
 
-  &__guest-login, &__signup {
+  &__guest-login, &__signup, &__delete {
     margin-bottom: 2%;
     font-size: 1.6rem;
   }

--- a/app/assets/stylesheets/Object/Project/user-edit.scss
+++ b/app/assets/stylesheets/Object/Project/user-edit.scss
@@ -1,7 +1,7 @@
 @import "Object/Utility/colors";
 @import "Object/Utility/prefix";
 
-.datespot-edit {
+.user-edit {
   margin-bottom: 2%;
 
   &__description-title {

--- a/app/views/datespots/_datespot_edit_form.html.erb
+++ b/app/views/datespots/_datespot_edit_form.html.erb
@@ -1,12 +1,18 @@
 <%= form_with model: @datespot, local: true do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
-  <% if @datespot.images.present? %>
-    <p>現在登録されている画像（削除するものはチェックしてください）</p>
-    <% @datespot.images.each do |image| %>
-      <%= form.check_box :image_ids, {multiple: true}, image.id, false %>
-      <%= image_tag image.variant(resize:'200x200').processed  %> <br>
+  <div class="datespot-edit">
+    <% if @datespot.images.present? %>
+      <p class="datespot-edit__description-title">現在登録されている画像</p><p class="datespot-edit__description-attention">※削除する画像はチェックしてください</p>
+      <% @datespot.images.each do |image| %>
+        <%= form.check_box :image_ids, {multiple: true}, image.id, false %>
+        <%= image_tag image.variant(resize:'250x250').processed, class:"datespot-edit__image"  %><br>
+      <% end %>
+    <% else %>
+      <p class="datespot-edit__description-title">現在登録されている画像</p><p class="datespot-edit__description-no-image">なし</p>
     <% end %>
-  <% end %>
+  </div>
   <%= render partial: 'datespot_info_form', locals: { form: form } %>
 <% end %>
-<%= render "map-new" %>
+<div class="info-form__delete">
+  <%= link_to "投稿を削除する", datespot_path(@datespot), method: :delete, data: { confirm: "本当にこの投稿を削除してもよろしいですか？" } %>
+</div>

--- a/app/views/datespots/edit.html.erb
+++ b/app/views/datespots/edit.html.erb
@@ -1,12 +1,16 @@
-<% provide(:title, "投稿編集") %>
+<% provide(:title, "編集する") %>
 <% provide(:button_text, "更新する") %>
-<div class="container">
-  <h1>編集する</h1>
+<div class="container-fluid">
   <div class="row">
-    <div class="col-md-6 col-md-offset-3">
-      <%= render 'datespot_edit_form' %>
-      <%= link_to "投稿を削除する", datespot_path(@datespot), method: :delete,
-                             data: { confirm: "本当にこの投稿を削除してもよろしいですか？" } %>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">編集する</h1>
+      </div>
+      <div class="content">
+        <%= render 'datespot_edit_form' %>
+      </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
 </div>

--- a/app/views/users/_user_edit_form.html.erb
+++ b/app/views/users/_user_edit_form.html.erb
@@ -1,11 +1,18 @@
 <%= form_with model: @user, local: true do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
-  <% if @user.avatars.present? %>
-    <p>現在登録されている画像（削除するものはチェックしてください）</p>
+  <div class="user-edit">
+    <% if @user.avatars.present? %>
+      <p class="user-edit__description-title">現在登録されている画像</p><p class="user-edit__description-attention">※削除する画像はチェックしてください</p>
     <% @user.avatars.each do |avatar| %>
       <%= form.check_box :avatar_ids, {multiple: true}, avatar.id, false %>
-      <%= image_tag avatar.variant(resize:'200x200').processed  %> <br>
+      <%= image_tag avatar.variant(resize:'250x250').processed, class:"user-edit__image" %><br>
     <% end %>
-  <% end %>
+    <% else %>
+      <p class="user-edit__description-title">現在登録されている画像</p><p class="user-edit__description-no-image">なし</p>
+    <% end %>
+  </div>
   <%= render partial: 'user_info_form', locals: { form: form } %>
 <% end %>
+<div class="info-form__delete">
+  <%= link_to "ユーザーを削除する", user_path(@user), method: :delete, data: { confirm: "本当にこのユーザーを削除してもよろしいですか？" } %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,10 +1,16 @@
-<% provide(:title, "ユーザー編集") %>
+<% provide(:title, "編集する") %>
 <% provide(:button_text, "更新する") %>
-<h1>編集する</h1>
-<div class="row">
-  <div class="col-md-6 col-md-offset-3">
-    <%= render 'user_edit_form' %>
-    <%= link_to "ユーザーを削除する", user_path(@user), method: :delete,
-                            data: { confirm: "本当にこのユーザーを削除してもよろしいですか？" } %>
+<div class="container-fluid">
+  <div class="row">
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">編集する</h1>
+      </div>
+      <div class="content">
+        <%= render 'user_edit_form' %>
+      </div>
+      <%= render 'layouts/footer' %>
+    </div>
   </div>
 </div>

--- a/spec/system/datespots_spec.rb
+++ b/spec/system/datespots_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe "Datespots", type: :system do
 
     context "ページレイアウト" do
       it "正しいタイトルが表示されること" do
-        expect(page).to have_title full_title('投稿編集')
+        expect(page).to have_title full_title('編集する')
       end
 
       it "入力部分に適切なラベルが表示されること" do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Users", type: :system do
 
     context "ページレイアウト" do
       it "正しいタイトルが表示されることを確認" do
-        expect(page).to have_title full_title('ユーザー編集')
+        expect(page).to have_title full_title('編集する')
       end
     end
 


### PR DESCRIPTION
Closes #161 

### 【概要】
・投稿編集ページのレイアウトを変更
・ユーザー編集ページのレイアウトを変更
・投稿・ユーザー編集ページのデザイン修正に伴うテストの修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)