### PR TITLE
feat:マッチング一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/matching-index.scss
+++ b/app/assets/stylesheets/Object/Project/matching-index.scss
@@ -1,0 +1,54 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.matching-index {
+  &__user-count {
+    font-size: 2.4rem;
+  }
+
+  &__match-users {
+    display:flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: 50%;
+    margin: 0 auto;
+    margin-bottom: 5%;
+    padding-bottom: 10px;
+    border-bottom: 2px solid $font-color__wine-red;
+
+    &--avatar {
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+      object-fit: cover;
+      margin-right: 5%;
+    }
+
+    &--name {
+      font-size: 2rem;
+    }
+  }
+
+  &__match-users >:last-child {
+    margin-left: auto;
+  }
+
+  &__room-entry {
+    &--icon {
+      background: $font-color__wine-red;
+      border-style: none;
+      font-size: 3rem;
+      width: 50px;
+      height: 50px;
+      border-radius: 5px;
+
+      i {
+        color: white;
+      }
+    }
+  }
+
+  &__no-user {
+    font-size: 2.4rem;
+  }
+}

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,25 +1,41 @@
 <% provide(:title, "マッチング一覧") %>
-<div class="container">
+<div class="container-fluid">
   <div class="row">
-    <% if @match_users.present?%>
-      <h3><%= @match_users.size %>人とマッチングしています</h3>
-      <h4>マッチング一覧</h4>
-      <% @match_users.each do |match_user| %>
-        <section class="user_info">
-          <% if match_user.avatars.attached? %>
-            <div class="swiper-slide"><%= image_tag match_user.avatars.first.variant(resize:'50x50').processed %></div>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">マッチング一覧</h1>
+      </div>
+      <div class="content">
+        <div class="matching-index">
+          <% if @match_users.present?%>
+            <p class="matching-index__user-count"><%= @match_users.size %>人とマッチングしています</p>
+            <ul>
+              <% @match_users.each do |match_user| %>
+                <li class="matching-index__match-users">
+                  <% if match_user.avatars.attached? %>
+                    <%= image_tag match_user.avatars.first.variant(resize:'50x50').processed, class: "matching-index__match-users--avatar" %>
+                  <% else %>
+                    <%= image_tag 'thumb50_default.png', class: "matching-index__match-users--avatar" %>
+                  <% end %>
+                  <span class="matching-index__match-users--name"><%= link_to match_user.name, match_user %></span>
+                  <div class="matching-index__room-entry">
+                    <%= form_with model: @room do |form| %>
+                      <%= form.hidden_field :user_id, value: match_user.id %>
+                      <%= form.button :type => "submit", class: "matching-index__room-entry--icon" do %>
+                        <i class="far fa-comment-dots"></i>
+                      <% end %>
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
           <% else %>
-            <%= image_tag 'thumb50_default.png'%>
+            <p class="matching-index__no-user">マッチングしているユーザーはいません</p>
           <% end %>
-          <p class="user-name"><%= link_to match_user.name, match_user %></p>
-        </section>
-        <%= form_with model: @room do |form| %>
-          <%= form.hidden_field :user_id, value: match_user.id %>
-          <%= form.submit "メッセージをする", class: "btn btn-primary" %>
-        <% end %>
-      <% end %>
-    <% else %>
-      <h4>マッチングしているユーザーはいません</h4>
-    <% end %>
+        </div>
+      </div>
+      <%= render 'layouts/footer' %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Closes #163 

### 【概要】
・マッチング一覧ページのレイアウトを変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)