### PR TITLE
feat:お気に入り一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Foundation/reset.scss
+++ b/app/assets/stylesheets/Foundation/reset.scss
@@ -36,17 +36,6 @@ h4 {
 
 /* ↓は後で修正 */
 
-// ユーザー一覧ページ
-.users {
-  list-style: none;
-  margin: 0;
-  li {
-    overflow: auto;
-    padding: 10px 0;
-    border-bottom: 1px;
-  }
-}
-
 //通知
 li.new_notification > a > span {
   color: red;

--- a/app/assets/stylesheets/Object/Project/favorite-index.scss
+++ b/app/assets/stylesheets/Object/Project/favorite-index.scss
@@ -1,21 +1,28 @@
 @import "Object/Utility/colors";
 @import "Object/Utility/prefix";
 
-.datespot-index {
+.favorite-index {
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
+  align-items: center;
+  width: 75%;
+  margin: 0 auto;
+  margin-bottom: 5%;
+  padding-bottom: 10px;
+  border-bottom: 1.5px solid $font-color__wine-red;
 
-  &__no-datespot-large {
+  &__datespot-count {
+    display: inline-block;
+    margin-bottom: 3%;
     font-size: 2.4rem;
   }
 
-  &__no-datespot-small {
-    font-size: 1.8rem;
+  &__no-datespot {
+    font-size: 2.4rem;
   }
 
   &__card {
-    width: 30%;
+    width: 40%;
     height: 100%;
     margin-bottom: 3%;
     text-align: left;
@@ -37,5 +44,14 @@
 
   &__card-lower {
     margin: 5%;
+  }
+
+  &__info {
+    font-size: 1.8rem;
+
+    &--description, &--timestamp, &--unlike, {
+      display: inline-block;
+      margin-bottom: 10%;
+    }
   }
 }

--- a/app/assets/stylesheets/Object/Project/matching-index.scss
+++ b/app/assets/stylesheets/Object/Project/matching-index.scss
@@ -14,7 +14,7 @@
     margin: 0 auto;
     margin-bottom: 5%;
     padding-bottom: 10px;
-    border-bottom: 2px solid $font-color__wine-red;
+    border-bottom: 1.5px solid $font-color__wine-red;
 
     &--avatar {
       border-radius: 50%;

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,7 +2,7 @@ class FavoritesController < ApplicationController
   before_action :logged_in_user
 
   def index
-    @favorites = current_user.favorites.preload(datespot: { images_attachments: :blob }).sort_desc
+    @favorites = current_user.favorites.preload(datespot: { images_attachments: :blob }).paginate(page: params[:page], per_page: 5).sort_desc
     @datespots = current_user.favorite_datespots
   end
 

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,30 +1,27 @@
 <% @datespot = Datespot.find(favorite.datespot_id) %>
-<li id="datespot-<%= @datespot.id %>">
-  <p><%= l favorite.created_at %></p>
-  <div class="row">
-    <div class="col-md-4">
-      <div class="favorite-datespot">
-        <p class="list-message">この投稿をお気に入りに追加しました。</p>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <%= link_to "お気に入りから削除", "/favorites/#{@datespot.id}/destroy",
-                                  method: :delete,
-                                  class: 'unlike',
-                                  data: { confirm: "本当にお気に入りから削除しますか？" } %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-3">
+<li class="favorite-index" id="favorite-<%= favorite.id %>">
+  <div class="favorite-index__card" id="datespot-<%= @datespot.id %>">
+    <div class="favorite-index__card-upper">
       <% if @datespot.images.attached? %>
-        <%= image_tag @datespot.images.first.variant(resize:'200x200').processed %>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "favorite-index__card-upper--image" %>
+        <% end %>
       <% else %>
-        <%= image_tag 'thumb200_default.png'%>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag 'thumb400_default.png', class: "favorite-index__card-upper--image" %>
+        <% end %>
       <% end %>
     </div>
-    <div class="col-md-6">
-      <%= render 'datespots/datespot_evaluation' %><br>
+    <div class="favorite-index__card-lower">
       <%= render 'datespots/datespot_index_info' %>
     </div>
+  </div>
+  <div class="favorite-index__info">
+    <p class="favorite-index__info--description">この提案をお気に入りに追加しました。</p><br>
+    <p class="favorite-index__info--timestamp"><%= l favorite.created_at %></p><br>
+    <%= link_to "お気に入りから削除", "/favorites/#{@datespot.id}/destroy",
+                                    method: :delete,
+                                    class: 'favorite-index__info--unlike',
+                                    data: { confirm: "本当にお気に入りから削除しますか？" } %>
   </div>
 </li>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,15 +1,23 @@
 <% provide(:title, "お気に入り一覧") %>
-<div class="container">
+<div class="container-fluid">
   <div class="row">
-    <div class="col-md-12">
-      <h3>お気に入り一覧 (<%= @favorites.count %>)</h3>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">お気に入り一覧</h1>
+      </div>
+      <div class="content">
+        <% if @favorites.present? %>
+          <p class="favorite-index__datespot-count">お気に入りの提案： <%= @favorites.count %>件</p>
+          <ol>
+            <%= render @favorites %>
+          </ol>
+          <%= will_paginate @favorites, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
+        <% else %>
+          <span class="favorite-index__no-datespot">まだお気に入りはありません</span>
+        <% end %>
+      </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
-  <% if @favorites.present? %>
-    <ol class="favorites">
-      <%= render @favorites %>
-    </ol>
-  <% else %>
-    <p>お気に入りはありません</p>
-  <% end %>
 </div>

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe "Favorites", type: :system do
     end
 
     it "お気に入り一覧ページが期待通り表示されること" do
-      expect(page).not_to have_css ".favorite-datespot"
+      expect(page).not_to have_css ".favorite-index"
       user.favorite(datespot)
       user.favorite(other_datespot)
       visit favorites_path
-      expect(page).to have_css ".favorite-datespot", count: 2
+      expect(page).to have_css ".favorite-index", count: 2
       expect(page).to have_link datespot.name
       expect(page).to have_content datespot.address
       expect(page).to have_content datespot.range_i18n
@@ -38,7 +38,7 @@ RSpec.describe "Favorites", type: :system do
       expect(page).to have_link other_datespot.user.name
       user.unfavorite(other_datespot)
       visit favorites_path
-      expect(page).to have_css ".favorite-datespot", count: 1
+      expect(page).to have_css ".favorite-index", count: 1
       expect(page).to have_link datespot.name
     end
   end


### PR DESCRIPTION
Closes #165 

### 【概要】
・お気に入り一覧ページのレイアウトを変更
・お気に入り一覧ページのデザイン修正に伴うテストの修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)