### PR TITLE
feat:行きたい！一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/list-index.scss
+++ b/app/assets/stylesheets/Object/Project/list-index.scss
@@ -1,7 +1,7 @@
 @import "Object/Utility/colors";
 @import "Object/Utility/prefix";
 
-.favorite-index {
+.list-index {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -49,7 +49,7 @@
   &__info {
     font-size: 1.8rem;
 
-    &--description, &--timestamp, &--unlike {
+    &--description, &--timestamp {
       display: inline-block;
       margin-bottom: 10%;
     }

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -2,7 +2,7 @@ class ListsController < ApplicationController
   before_action :logged_in_user
 
   def index
-    @lists = current_user.lists.preload(datespot: { images_attachments: :blob }).sort_desc
+    @lists = current_user.lists.preload(datespot: { images_attachments: :blob }).paginate(page: params[:page], per_page: 5).sort_desc
   end
 
   def create

--- a/app/views/datespots/index.html.erb
+++ b/app/views/datespots/index.html.erb
@@ -18,7 +18,7 @@
           </ol>
           <%= will_paginate @datespots, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
         <% else %>
-          <span class="datespot-index__no-datespot-large">まだ提案がありません</span>
+          <span class="datespot-index__no-datespot-large">提案はありません</span>
         <% end %>
         <% if logged_in? %>
           <span class="fab">

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="favorite-index__info">
-    <p class="favorite-index__info--description">この提案をお気に入りに追加しました。</p><br>
+    <p class="favorite-index__info--description">この提案をお気に入りに追加しました</p><br>
     <p class="favorite-index__info--timestamp"><%= l favorite.created_at %></p><br>
     <%= link_to "お気に入りから削除", "/favorites/#{@datespot.id}/destroy",
                                     method: :delete,

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -14,7 +14,7 @@
           </ol>
           <%= will_paginate @favorites, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
         <% else %>
-          <span class="favorite-index__no-datespot">まだお気に入りはありません</span>
+          <span class="favorite-index__no-datespot">お気に入りはありません</span>
         <% end %>
       </div>
       <%= render 'layouts/footer' %>

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,36 +1,24 @@
-<% @list = list %>
 <% @datespot = Datespot.find(list.datespot_id) %>
 <% user = User.find(list.from_user_id) %>
-<li id="list-<%= list.id %>">
-  <p><%= l list.created_at %></p>
-  <div class="row">
-    <div class="col-md-4">
-      <div class="list-datespot">
-        <% if list.user_id == list.from_user_id %>
-          <p class="list-message">この投稿を行く予定リストに追加しました。</p>
-        <% else %>
-          <p class="list-message"><%= link_to user.name, user_path(user) %>さんがこの投稿に行きたいリクエストをしました。</p>
-        <% end %>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <%= link_to "リストから削除", "/lists/#{list.id}/destroy",
-                                  method: :delete,
-                                  class: "unlist",
-                                  data: { confirm: "本当にリストから削除しますか？" } %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-3">
+<li class="list-index" id="list-<%= list.id %>">
+  <div class="list-index__card" id="datespot-<%= @datespot.id %>">
+    <div class="list-index__card-upper">
       <% if @datespot.images.attached? %>
-        <%= image_tag @datespot.images.first.variant(resize:'200x200').processed %>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "list-index__card-upper--image" %>
+        <% end %>
       <% else %>
-        <%= image_tag 'thumb200_default.png'%>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag 'thumb400_default.png', class: "list-index__card-upper--image" %>
+        <% end %>
       <% end %>
     </div>
-    <div class="col-md-6">
-      <%= render 'datespots/datespot_evaluation' %><br>
+    <div class="list-index__card-lower">
       <%= render 'datespots/datespot_index_info' %>
     </div>
+  </div>
+  <div class="list-index__info">
+    <p class="list-index__info--description"><%= link_to user.name, user_path(user) %>さんが<br>この提案に行きたい！リクエストをしました</p><br>
+    <p class="list-index__info--timestamp"><%= l list.created_at %></p><br>
   </div>
 </li>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,15 +1,23 @@
-<% provide(:title, "行く予定リスト") %>
-<div class="container">
+<% provide(:title, "行きたい！一覧") %>
+<div class="container-fluid">
   <div class="row">
-    <div class="col-md-12">
-      <h3>行く予定リスト (<%= @lists.count %>)</h3>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">行きたい！一覧</h1>
+      </div>
+      <div class="content">
+        <% if @lists.present? %>
+          <p class="list-index__datespot-count">行きたい！リクエスト： <%= @lists.count %>件</p>
+          <ol>
+            <%= render @lists %>
+          </ol>
+          <%= will_paginate @lists, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
+        <% else %>
+          <span class="list-index__no-datespot">行きたい！リクエストはありません</span>
+        <% end %>
+      </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
-  <% if @lists.present? %>
-    <ol class="lists">
-      <%= render @lists %>
-    </ol>
-  <% else %>
-    <p>リストはありません</p>
-  <% end %>
 </div>

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Favorites", type: :system do
       user.favorite(other_datespot)
       visit favorites_path
       expect(page).to have_css ".favorite-index", count: 2
+      expect(page).to have_content "この提案をお気に入りに追加しました"
       expect(page).to have_link datespot.name
       expect(page).to have_content datespot.address
       expect(page).to have_content datespot.range_i18n

--- a/spec/system/lists_spec.rb
+++ b/spec/system/lists_spec.rb
@@ -6,45 +6,44 @@ RSpec.describe "Lists", type: :system do
   let!(:datespot) { create(:datespot, user: user) }
   let!(:datespot_2) { create(:datespot, user: user) }
 
-  describe "行く予定リストページ" do
+  describe "行きたい！一覧ページ" do
     before do
-      login_for_system(user)
+      login_for_system(other_user)
       visit lists_path
     end
 
-    it "「行く予定リスト」の文字列が存在すること" do
-      expect(page).to have_content '行く予定リスト'
+    it "「行きたい！一覧」の文字列が存在すること" do
+      expect(page).to have_content '行きたい！一覧'
     end
 
     it "正しいタイトルが表示されること" do
-      expect(page).to have_title full_title('行く予定リスト')
+      expect(page).to have_title full_title('行きたい！一覧')
     end
 
-    it "行く予定リストページが期待通り表示され、リストから削除することもできること" do
-      expect(page).not_to have_css ".list-datespot"
-      user.list(datespot)
+    it "行きたい！一覧ページが期待通り表示されること" do
+      expect(page).not_to have_css ".list-index"
+      other_user.list(datespot)
       other_user.list(datespot_2)
+      login_for_system(user)
       visit lists_path
-      expect(page).to have_css ".list-datespot", count: 2
-      expect(page).to have_content "この投稿を行く予定リストに追加しました。"
+      expect(page).to have_css ".list-index", count: 2
+      expect(page).to have_content "#{other_user.name}さんがこの提案に行きたい！リクエストをしました"
       expect(page).to have_link datespot.name
       expect(page).to have_content datespot.address
       expect(page).to have_content datespot.range_i18n
       expect(page).to have_content datespot.tag_list
       expect(page).to have_link datespot.user.name
-      expect(page).to have_content "#{other_user.name}さんがこの投稿に行きたいリクエストをしました。"
       expect(page).to have_link datespot_2.name
       expect(page).to have_content datespot_2.address
       expect(page).to have_content datespot_2.range_i18n
       expect(page).to have_content datespot_2.tag_list
       expect(page).to have_link datespot_2.user.name
-      user.unlist(List.last)
+      login_for_system(other_user)
+      other_user.unlist(List.last)
+      login_for_system(user)
       visit lists_path
-      expect(page).to have_css ".list-datespot", count: 1
+      expect(page).to have_css ".list-index", count: 1
       expect(page).to have_content datespot.name
-      find('.unlist').click
-      visit lists_path
-      expect(page).not_to have_css ".list-datespot"
     end
   end
 end


### PR DESCRIPTION
Closes #167 

### 【概要】
・行きたい！一覧ページのレイアウトを変更
・行きたい！一覧ページのデザイン修正に伴うテストの修正

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)