### PR TITLE
feat:閲覧履歴一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/history-index.scss
+++ b/app/assets/stylesheets/Object/Project/history-index.scss
@@ -1,0 +1,57 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.history-index {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 75%;
+  margin: 0 auto;
+  margin-bottom: 5%;
+  padding-bottom: 10px;
+  border-bottom: 1.5px solid $font-color__wine-red;
+
+  &__datespot-count {
+    display: inline-block;
+    margin-bottom: 3%;
+    font-size: 2.4rem;
+  }
+
+  &__no-datespot {
+    font-size: 2.4rem;
+  }
+
+  &__card {
+    width: 40%;
+    height: 100%;
+    margin-bottom: 3%;
+    text-align: left;
+    background-color: white;
+    border: 1px solid $font-color__wine-red;
+  }
+
+  &__card-upper {
+    &--image {
+      width: 100%;
+      opacity: 1;
+      transition: 0.5s ease-in-out;
+    }
+
+    &--image:hover {
+      opacity: 0.5;
+    }
+  }
+
+  &__card-lower {
+    margin: 5%;
+  }
+
+  &__info {
+    font-size: 1.8rem;
+
+    &--description, &--timestamp {
+      display: inline-block;
+      margin-bottom: 10%;
+    }
+  }
+}

--- a/app/controllers/browsing_histories_controller.rb
+++ b/app/controllers/browsing_histories_controller.rb
@@ -2,6 +2,6 @@ class BrowsingHistoriesController < ApplicationController
   before_action :logged_in_user
 
   def index
-    @histories = current_user.browsing_histories.preload(:datespot, datespot: { images_attachments: :blob }).sort_desc
+    @histories = current_user.browsing_histories.preload(:datespot, datespot: { images_attachments: :blob }).paginate(page: params[:page], per_page: 5).sort_desc
   end
 end

--- a/app/controllers/datespots_controller.rb
+++ b/app/controllers/datespots_controller.rb
@@ -22,7 +22,7 @@ class DatespotsController < ApplicationController
       end
       new_history.save
 
-      histories_stock_limit = 5
+      histories_stock_limit = 10
       histories = current_user.browsing_histories.all
       if histories.count > histories_stock_limit
         histories[0].destroy

--- a/app/views/browsing_histories/_browsing_history.html.erb
+++ b/app/views/browsing_histories/_browsing_history.html.erb
@@ -1,24 +1,23 @@
 <% @datespot = Datespot.find(browsing_history.datespot_id) %>
-<li id="datespot-<%= @datespot.id %>">
-  <p><%= l browsing_history.created_at %></p>
-  <div class="row">
-    <div class="col-md-4">
-      <div class="browsing_history-datespot">
-        <p class="list-message">この投稿を閲覧しました。</p>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-3">
+<li class="history-index" id="browsing_history-<%= browsing_history.id %>">
+  <div class="history-index__card" id="datespot-<%= @datespot.id %>">
+    <div class="history-index__card-upper">
       <% if @datespot.images.attached? %>
-        <%= image_tag @datespot.images.first.variant(resize:'200x200').processed %>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "history-index__card-upper--image" %>
+        <% end %>
       <% else %>
-        <%= image_tag 'thumb200_default.png'%>
+        <%= link_to datespot_path(@datespot) do %>
+          <%= image_tag 'thumb400_default.png', class: "history-index__card-upper--image" %>
+        <% end %>
       <% end %>
     </div>
-    <div class="col-md-6">
-      <%= render 'datespots/datespot_evaluation' %><br>
+    <div class="history-index__card-lower">
       <%= render 'datespots/datespot_index_info' %>
     </div>
+  </div>
+  <div class="history-index__info">
+    <p class="history-index__info--description">この提案を閲覧しました</p><br>
+    <p class="history-index__info--timestamp"><%= l browsing_history.created_at %></p>
   </div>
 </li>

--- a/app/views/browsing_histories/index.html.erb
+++ b/app/views/browsing_histories/index.html.erb
@@ -1,15 +1,23 @@
 <% provide(:title, "閲覧履歴一覧") %>
-<div class="container">
+<div class="container-fluid">
   <div class="row">
-    <div class="col-md-12">
-      <h3>閲覧履歴一覧 (<%= @histories.count %>)</h3>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">閲覧履歴一覧</h1>
+      </div>
+      <div class="content">
+        <% if @histories.present? %>
+          <p class="history-index__datespot-count">閲覧履歴： <%= @histories.count %>件<br>(最大10件まで)</p>
+          <ol>
+            <%= render @histories %>
+          </ol>
+          <%= will_paginate @histories, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
+        <% else %>
+          <span class="history-index__no-datespot">履歴はありません</span>
+        <% end %>
+      </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
-  <% if @histories.present? %>
-    <ol class="histories">
-      <%= render @histories %>
-    </ol>
-  <% else %>
-    <p>履歴はありません</p>
-  <% end %>
 </div>


### PR DESCRIPTION
Closes #169 

### 【概要】
・閲覧履歴一覧ページのレイアウトを変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)