### PR TITLE
feat:通知一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/favorite-index.scss
+++ b/app/assets/stylesheets/Object/Project/favorite-index.scss
@@ -47,6 +47,7 @@
   }
 
   &__info {
+    width: 40%;
     font-size: 1.8rem;
 
     &--description, &--timestamp, &--unlike {

--- a/app/assets/stylesheets/Object/Project/history-index.scss
+++ b/app/assets/stylesheets/Object/Project/history-index.scss
@@ -47,6 +47,7 @@
   }
 
   &__info {
+    width: 40%;
     font-size: 1.8rem;
 
     &--description, &--timestamp {

--- a/app/assets/stylesheets/Object/Project/notification-index.scss
+++ b/app/assets/stylesheets/Object/Project/notification-index.scss
@@ -1,7 +1,7 @@
 @import "Object/Utility/colors";
 @import "Object/Utility/prefix";
 
-.list-index {
+.notification-index {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -11,13 +11,18 @@
   padding-bottom: 10px;
   border-bottom: 1.5px solid $font-color__wine-red;
 
-  &__datespot-count {
+  &__notification-count {
     display: inline-block;
-    margin-bottom: 3%;
     font-size: 2.4rem;
   }
 
-  &__no-datespot {
+  &__notification-all-delete {
+    display: inline-block;
+    margin-bottom: 3%;
+    font-size: 1.8rem;
+  }
+
+  &__no-notification {
     font-size: 2.4rem;
   }
 
@@ -50,7 +55,7 @@
     width: 40%;
     font-size: 1.8rem;
 
-    &--description, &--timestamp {
+    &--description, &--timestamp, &--unlike {
       display: inline-block;
       margin-bottom: 10%;
     }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@ class NotificationsController < ApplicationController
   before_action :logged_in_user
 
   def index
-    @notifications = current_user.notifications.preload(datespot: { images_attachments: :blob }).sort_desc
+    @notifications = current_user.notifications.preload(datespot: { images_attachments: :blob }).paginate(page: params[:page], per_page: 5).sort_desc
     current_user.update_attribute(:notification, false)
   end
 

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="favorite-index__info">
-    <p class="favorite-index__info--description">この提案をお気に入りに追加しました</p><br>
+    <p class="favorite-index__info--description">この提案をお気に入りに<br>追加しました</p><br>
     <p class="favorite-index__info--timestamp"><%= l favorite.created_at %></p><br>
     <%= link_to "お気に入りから削除", "/favorites/#{@datespot.id}/destroy",
                                     method: :delete,

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -18,7 +18,7 @@
     </div>
   </div>
   <div class="list-index__info">
-    <p class="list-index__info--description"><%= link_to user.name, user_path(user) %>さんが<br>この提案に行きたい！リクエストをしました</p><br>
+    <p class="list-index__info--description"><%= link_to user.name, user_path(user) %>さんがこの提案に<br>行きたい！リクエストをしました</p><br>
     <p class="list-index__info--timestamp"><%= l list.created_at %></p><br>
   </div>
 </li>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,36 +1,89 @@
 <% @user = User.find(notification.from_user_id) %>
 <% @datespot = Datespot.find(notification.datespot_id) if notification.datespot_id.present? %>
-<li id="notification-<%= notification.id %>">
-  <div>
-    <% if notification.variety == 1 %>
-      <p><%= l notification.created_at %></p>
-      <p class="notification-message">あなたの投稿が<%= link_to @user.name, user_path(@user) %>さんから行きたいリクエストされました。</p>
-    <% elsif notification.variety == 2 %>
-      <p><%= l notification.created_at %></p>
-      <p class="notification-message">あなたの投稿に<%= link_to @user.name, user_path(@user) %>さんがコメントしました。
-      「<%= notification.content %>」</p>
-    <% elsif notification.variety == 3 %>
-      <p><%= l notification.created_at %></p>
-      <p class="notification-message"><%= link_to @user.name, user_path(@user) %>さんがあなたにいいねをしました。</p>
-    <% elsif notification.variety == 4 %>
-      <p><%= l notification.created_at %></p>
-      <p class="notification-message"><%= link_to @user.name, user_path(@user) %>さんからメッセージが届きました。
-      「<%= notification.content %>」</p>
-    <% end %>
-  </div>
-  <% if @datespot.present? %>
-    <div class="row">
-      <div class="col-md-3">
-      <% if @datespot.images.attached? %>
-        <%= image_tag @datespot.images.first.variant(resize:'200x200').processed %>
-      <% else %>
-        <%= image_tag 'thumb200_default.png'%>
-      <% end %>
+<li class="notification-index" id="notification-<%= notification.id %>">
+  <% if notification.variety == 1 %>
+    <div class="notification-index__card" id="datespot-<%= @datespot.id %>">
+      <div class="notification-index__card-upper">
+        <% if @datespot.images.attached? %>
+          <%= link_to datespot_path(@datespot) do %>
+            <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% else %>
+          <%= link_to datespot_path(@datespot) do %>
+            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% end %>
       </div>
-    <div class="col-md-6">
-      <%= render 'datespots/datespot_evaluation' %><br>
-      <%= render 'datespots/datespot_info' %>
+      <div class="notification-index__card-lower">
+        <%= render 'datespots/datespot_index_info' %>
+      </div>
     </div>
+    <div class="notification-index__info">
+      <p class="notification-index__info--description">あなたの提案に<%= link_to @user.name, user_path(@user) %>さんが<br>行きたい！リクエストをしました</p><br>
+      <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
+    </div>
+  <% elsif notification.variety == 2 %>
+    <div class="notification-index__card" id="datespot-<%= @datespot.id %>">
+      <div class="notification-index__card-upper">
+        <% if @datespot.images.attached? %>
+          <%= link_to datespot_path(@datespot) do %>
+            <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% else %>
+          <%= link_to datespot_path(@datespot) do %>
+            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="notification-index__card-lower">
+        <%= render 'datespots/datespot_index_info' %>
+      </div>
+    </div>
+    <div class="notification-index__info">
+      <p class="notification-index__info--description">あなたの提案に<br><%= link_to @user.name, user_path(@user) %>さんがコメントしました<br>「<%= notification.content.slice(0..10) %>...」</p><br>
+      <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
+    </div>
+  <% elsif notification.variety == 3 %>
+    <div class="notification-index__card" id="user-<%= @user.id %>">
+      <div class="notification-index__card-upper">
+        <% if @user.avatars.attached? %>
+          <%= link_to user_path(@user) do %>
+            <%= image_tag @user.avatars.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% else %>
+          <%= link_to user_path(@user) do %>
+            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="notification-index__card-lower">
+        <%= render 'users/user_index_info' %>
+      </div>
+    </div>
+    <div class="notification-index__info">
+      <p class="notification-index__info--description"><%= link_to @user.name, user_path(@user) %>さんが<br>あなたにいいね！をしました</p><br>
+      <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
+    </div>
+  <% elsif notification.variety == 4 %>
+    <div class="notification-index__card" id="user-<%= @user.id %>">
+      <div class="notification-index__card-upper">
+        <% if @user.avatars.attached? %>
+          <%= link_to user_path(@user) do %>
+            <%= image_tag @user.avatars.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% else %>
+          <%= link_to user_path(@user) do %>
+            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="notification-index__card-lower">
+        <%= render 'users/user_index_info' %>
+      </div>
+    </div>
+    <div class="notification-index__info">
+      <p class="notification-index__info--description"><%= link_to @user.name, user_path(@user) %>さんから<br>メッセージが届きました<br>「<%= notification.content.slice(0..10) %>...」</p><br>
+      <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
     </div>
   <% end %>
 </li>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -2,85 +2,25 @@
 <% @datespot = Datespot.find(notification.datespot_id) if notification.datespot_id.present? %>
 <li class="notification-index" id="notification-<%= notification.id %>">
   <% if notification.variety == 1 %>
-    <div class="notification-index__card" id="datespot-<%= @datespot.id %>">
-      <div class="notification-index__card-upper">
-        <% if @datespot.images.attached? %>
-          <%= link_to datespot_path(@datespot) do %>
-            <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% else %>
-          <%= link_to datespot_path(@datespot) do %>
-            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% end %>
-      </div>
-      <div class="notification-index__card-lower">
-        <%= render 'datespots/datespot_index_info' %>
-      </div>
-    </div>
+    <%= render 'notifications/notification_datespot' %>
     <div class="notification-index__info">
       <p class="notification-index__info--description">あなたの提案に<%= link_to @user.name, user_path(@user) %>さんが<br>行きたい！リクエストをしました</p><br>
       <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
     </div>
   <% elsif notification.variety == 2 %>
-    <div class="notification-index__card" id="datespot-<%= @datespot.id %>">
-      <div class="notification-index__card-upper">
-        <% if @datespot.images.attached? %>
-          <%= link_to datespot_path(@datespot) do %>
-            <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% else %>
-          <%= link_to datespot_path(@datespot) do %>
-            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% end %>
-      </div>
-      <div class="notification-index__card-lower">
-        <%= render 'datespots/datespot_index_info' %>
-      </div>
-    </div>
+    <%= render 'notifications/notification_datespot' %>
     <div class="notification-index__info">
       <p class="notification-index__info--description">あなたの提案に<br><%= link_to @user.name, user_path(@user) %>さんがコメントしました<br>「<%= notification.content.slice(0..10) %>...」</p><br>
       <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
     </div>
   <% elsif notification.variety == 3 %>
-    <div class="notification-index__card" id="user-<%= @user.id %>">
-      <div class="notification-index__card-upper">
-        <% if @user.avatars.attached? %>
-          <%= link_to user_path(@user) do %>
-            <%= image_tag @user.avatars.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% else %>
-          <%= link_to user_path(@user) do %>
-            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% end %>
-      </div>
-      <div class="notification-index__card-lower">
-        <%= render 'users/user_index_info' %>
-      </div>
-    </div>
+    <%= render 'notifications/notification_user' %>
     <div class="notification-index__info">
       <p class="notification-index__info--description"><%= link_to @user.name, user_path(@user) %>さんが<br>あなたにいいね！をしました</p><br>
       <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>
     </div>
   <% elsif notification.variety == 4 %>
-    <div class="notification-index__card" id="user-<%= @user.id %>">
-      <div class="notification-index__card-upper">
-        <% if @user.avatars.attached? %>
-          <%= link_to user_path(@user) do %>
-            <%= image_tag @user.avatars.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% else %>
-          <%= link_to user_path(@user) do %>
-            <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
-          <% end %>
-        <% end %>
-      </div>
-      <div class="notification-index__card-lower">
-        <%= render 'users/user_index_info' %>
-      </div>
-    </div>
+    <%= render 'notifications/notification_user' %>
     <div class="notification-index__info">
       <p class="notification-index__info--description"><%= link_to @user.name, user_path(@user) %>さんから<br>メッセージが届きました<br>「<%= notification.content.slice(0..10) %>...」</p><br>
       <p class="notification-index__info--timestamp"><%= l notification.created_at %></p>

--- a/app/views/notifications/_notification_datespot.html.erb
+++ b/app/views/notifications/_notification_datespot.html.erb
@@ -1,0 +1,16 @@
+<div class="notification-index__card" id="datespot-<%= @datespot.id %>">
+  <div class="notification-index__card-upper">
+    <% if @datespot.images.attached? %>
+      <%= link_to datespot_path(@datespot) do %>
+        <%= image_tag @datespot.images.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+      <% end %>
+    <% else %>
+      <%= link_to datespot_path(@datespot) do %>
+        <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="notification-index__card-lower">
+    <%= render 'datespots/datespot_index_info' %>
+  </div>
+</div>

--- a/app/views/notifications/_notification_user.html.erb
+++ b/app/views/notifications/_notification_user.html.erb
@@ -1,0 +1,16 @@
+<div class="notification-index__card" id="user-<%= @user.id %>">
+  <div class="notification-index__card-upper">
+    <% if @user.avatars.attached? %>
+      <%= link_to user_path(@user) do %>
+        <%= image_tag @user.avatars.first.variant(resize:'400x400').processed, class: "notification-index__card-upper--image" %>
+      <% end %>
+    <% else %>
+      <%= link_to user_path(@user) do %>
+        <%= image_tag 'thumb400_default.png', class: "notification-index__card-upper--image" %>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="notification-index__card-lower">
+    <%= render 'users/user_index_info' %>
+  </div>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,19 +1,27 @@
 <% provide(:title, "通知一覧") %>
-<div class="container">
+<div class="container-fluid">
   <div class="row">
-    <div class="col-md-12">
-      <h3>通知一覧 (<%= @notifications.count %>)</h3>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title">通知一覧</h1>
+      </div>
+      <div class="content">
+        <% if @notifications.present? %>
+          <p class="notification-index__notification-count">通知： <%= @notifications.count %>件</p><br>
+          <div class="notification-index__notification-all-delete">
+            <%= link_to "全削除", "/notifications/destroy", method: :delete,
+            data: { confirm: '全ての通知を削除します。本当に削除してよろしいでしょうか？' } %>
+          </div>
+          <ol>
+            <%= render @notifications %>
+          </ol>
+          <%= will_paginate @notifications, previous_label: '<', next_label: '>', inner_window: 1, outer_window: 0 %>
+        <% else %>
+          <span class="notification-index__no-notification">通知はありません</span>
+        <% end %>
+      </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
-  <% if @notifications.present? %>
-    <div class="delete-notice">
-      <%= link_to "全削除", "/notifications/destroy", method: :delete,
-      data: { confirm: '全ての通知を削除します。本当に削除してよろしいでしょうか？' } %>
-    </div>
-    <ol class="notifications">
-      <%= render @notifications %>
-    </ol>
-  <% else %>
-    <p>通知はありません</p>
-  <% end %>
 </div>


### PR DESCRIPTION
Closes #171 

### 【概要】
・通知一覧ページのレイアウトを変更
・通知一覧ページのリファクタリング

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)