### PR TITLE
feat:メッセージ一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/Object/Project/matching-show.scss
+++ b/app/assets/stylesheets/Object/Project/matching-show.scss
@@ -1,0 +1,29 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.matching-show {
+  &__user-info {
+    display:flex;
+    justify-content: start;
+    align-items: center;
+    margin-bottom: 5%;
+    padding-bottom: 15px;
+    border-bottom: 1.5px solid $font-color__wine-red;
+
+    &--avatar {
+      border-radius: 50%;
+      width: 100px;
+      height: 100px;
+      object-fit: cover;
+      margin-right: 5%;
+    }
+
+    &--name {
+      font-size: 2.4rem;
+    }
+  }
+
+  &__messages-area {
+    margin-bottom: 5%;
+  }
+}

--- a/app/assets/stylesheets/Object/Project/message-form.scss
+++ b/app/assets/stylesheets/Object/Project/message-form.scss
@@ -1,0 +1,32 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.message-form {
+  margin-bottom: 5%;
+
+  &__error-messages{
+    font-size: 1.2rem;
+  }
+
+  label {
+    font-size: 1.8rem;
+  }
+
+  &__input-need, &__input-unneed {
+    font-size: 1.4rem;
+    margin-left: 1%;
+  }
+
+  &__input-form {
+    width: 40%;
+    font-size: 1.2rem;
+    line-height: 2;
+    border: 2px solid $font-color__wine-red;
+    border-radius: 5px;
+    background-color: white;
+  }
+
+  &__input-form::placeholder {
+    padding-left: 2%;
+  }
+}

--- a/app/assets/stylesheets/Object/Project/message-index.scss
+++ b/app/assets/stylesheets/Object/Project/message-index.scss
@@ -1,0 +1,83 @@
+@import "Object/Utility/colors";
+@import "Object/Utility/prefix";
+
+.message-index {
+  margin-bottom: 3%;
+
+  &__right {
+    text-align: right;
+
+    &--avatar {
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+      object-fit: cover;
+      margin-bottom: 1%;
+    }
+
+    &--message-content {
+      display: inline-block;
+      width: auto;
+      padding: 1%;
+      margin-bottom: 1%;
+      border: 2px solid $font-color__wine-red;
+      border-radius: 5px;
+      background-color: white;
+      font-size: 1.4rem;
+    }
+
+    &--message-picture {
+      margin-bottom: 1%;
+    }
+
+    &--bottom {
+      display:flex;
+      justify-content: flex-end;
+
+      &-timestamp {
+        font-size: 1.4rem;
+        margin-right: 1%;
+      }
+
+      i {
+        margin-right: 1%;
+        font-size: 1.8rem;
+      }
+    }
+  }
+
+  &__left {
+    text-align: left;
+
+    &--avatar {
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+      object-fit: cover;
+      margin-bottom: 1%;
+    }
+
+    &--message-content {
+      display: inline-block;
+      width: auto;
+      padding: 1%;
+      margin-bottom: 1%;
+      border: 2px solid $font-color__wine-red;
+      border-radius: 5px;
+      background-color: white;
+      font-size: 1.4rem;
+    }
+
+    &--message-picture {
+      margin-bottom: 1%;
+    }
+
+    &--timestamp {
+      font-size: 1.4rem;
+    }
+  }
+
+  &__no-message {
+    font-size: 2.4rem;
+  }
+}

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -4,7 +4,7 @@
     <%= form_with(model: [datespot, comment], url: datespot_comments_path(@datespot) ) do |form| %>
       <div id="error_messages" class='comment-form__error-messages'></div>
       <div class='comment-form' id="star">
-        <%= form.label :rate %><span class="comment-form__input-need">※必須(0.5~5の段階評価)</span><br/>
+        <%= form.label :rate %><span class="comment-form__input-need">※必須(0.5~5の段階評価)</span><br>
         <%= form.hidden_field :rate, required: true %>
       </div>
       <div class='comment-form'>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,13 +1,15 @@
 <%= form_with(model: [room, message]) do |form| %>
-  <div id="error_messages" class='comment-form__error-messages'></div>
-  <div class = 'form-group'>
-    <%= form.label :content %> <span class="info-form__input-need">※必須(255文字以内)</span>
-    <%= form.text_area :content, placeholder: "メッセージを入力", id: "message_content", required: true %>
+  <div id="error_messages" class='message-form__error-messages'></div>
+  <div class='message-form'>
+    <%= form.label :content %><span class="message-form__input-need">※必須(255文字以内)</span><br>
+    <%= form.text_area :content, placeholder: "メッセージを入力", class: 'message-form__input-form', id: "message_content", required: true %>
     <%= form.hidden_field :room_id, value: room.id %>
   </div>
-  <div class = 'form-group' id = "picture">
-    <%= form.label :picture %> <span class="info-form__input-unneed">※任意(1枚まで)</span>
-    <%= form.file_field :picture, id: 'message_picture' %>
+  <div class='message-form' id="picture">
+    <%= form.label :picture %><span class="message-form__input-unneed">※任意(1枚まで)</span><br>
+    <%= form.file_field :picture, class: 'message-form__input-form', id: 'message_picture' %>
   </div>
-  <%= form.submit "送信する", class: "btn btn-success" %>
+  <div class="action-button">
+    <%= form.submit "送信する", class: "action-button__submit" %>
+  </div>
 <% end %>

--- a/app/views/messages/_index.html.erb
+++ b/app/views/messages/_index.html.erb
@@ -1,30 +1,46 @@
 <% if messages.present? %>
   <ul>
     <% messages.each do |message| %>
-      <li id="message-<%= message.id %>">
-        <div class="chat-box">
-          <div class="chat-face">
+      <% if message.user == current_user %>
+        <li class="message-index" id="message-<%= message.id %>">
+          <div class="message-index__right">
             <% if message.user.avatars.attached? %>
-              <div class="swiper-slide"><%= image_tag message.user.avatars.first.variant(resize:'50x50').processed %></div>
+              <%= image_tag message.user.avatars.first.variant(resize:'50x50').processed, class: "message-index__right--avatar" %><br>
             <% else %>
-              <%= image_tag 'thumb50_default.png'%>
+              <%= image_tag 'thumb50_default.png', class: "message-index__right--avatar" %><br>
             <% end %>
-          </div>
-          <div class="chat-hukidashi">
-            <p class="current-user-name"><%= link_to message.user.name, user_path(message.user.id) %></p>
-            <p class="current-user-chat-text"><%= message.content %></p>
+            <p class="message-index__right--message-content"><%= message.content %></p><br>
             <% if message.picture.attached? %>
-              <%= image_tag message.picture.variant(resize:'200x200').processed %>
+              <%= image_tag message.picture.variant(resize:'200x200').processed, class: "message-index__right--message-picture" %>
             <% end %>
-            <p class="current-user-chat-time"><%= l message.created_at %></p>
-            <% if message.user == current_user %>
-              <%= link_to "削除",room_message_path(message.room_id, message.id), remote: true, method: :delete %>
-            <% end %>
+            <div class="message-index__right--bottom">
+              <p class="message-index__right--bottom-timestamp"><%= l message.created_at %></p>
+              <% if message.user == current_user %>
+                <%= link_to room_message_path(message.room_id, message.id), remote: true, method: :delete do %>
+                  <i class="far fa-trash-alt"></i>
+                <% end %>
+              <% end %>
+            </div>
           </div>
-        </div>
-      </li>
+        </li>
+      <% else %>
+        <li class="message-index" id="message-<%= message.id %>">
+          <div class="message-index__left">
+            <% if message.user.avatars.attached? %>
+              <%= image_tag message.user.avatars.first.variant(resize:'50x50').processed, class: "message-index__left--avatar" %><br>
+            <% else %>
+              <%= image_tag 'thumb50_default.png', class: "message-index__left--avatar" %><br>
+            <% end %>
+            <p class="message-index__left--message-content"><%= message.content %></p><br>
+            <% if message.picture.attached? %>
+              <%= image_tag message.picture.variant(resize:'200x200').processed, class: "message-index__left--message-picture" %>
+            <% end %>
+            <p class="message-index__left--timestamp"><%= l message.created_at %></p>
+          </div>
+        </li>
+      <% end %>
     <% end %>
   </ul>
 <% else %>
-  <h4>メッセージはまだありません</h4>
+  <p class="message-index__no-message">メッセージはありません</p>
 <% end %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,22 +1,30 @@
-<% provide(:title, "メッセージ一覧") %>
-<div class="container">
+<% provide(:title, "#{@message_user.name}さんとのメッセージ") %>
+<div class="container-fluid">
   <div class="row">
-    <p><%= link_to "マッチング一覧へ戻る", rooms_path %></p>
-    <section class="user_info">
-      <% if @message_user.avatars.attached? %>
-        <div class="swiper-slide"><%= image_tag @message_user.avatars.first.variant(resize:'200x200').processed %></div>
-      <% else %>
-        <%= image_tag 'thumb200_default.png'%>
-      <% end %>
-      <h4 class="user-name"><%= link_to @message_user.name, @message_user %></h4>
-    </section>
-    <div class="messages">
-      <div id="messages_area">
-        <%= render partial: 'messages/index', locals: { messages: @messages } %>
+    <%= render 'layouts/logging_in_sidebar' %>
+    <div class="main">
+      <div class="heading">
+        <h1 class="heading__title" id="datespot-name"><%= @message_user.name %>さんとのメッセージ</h1>
       </div>
-      <div class="messages_create">
-        <%= render partial: 'messages/form', locals: { message: @message, room: @room } %>
+      <div class="content">
+        <div class="matching-show">
+          <div class="matching-show__user-info">
+            <% if @message_user.avatars.attached? %>
+              <%= image_tag @message_user.avatars.first.variant(resize:'200x200').processed, class: "matching-show__user-info--avatar" %>
+            <% else %>
+              <%= image_tag 'thumb200_default.png', class: "matching-show__user-info--avatar" %>
+            <% end %>
+            <span class="matching-show__user-info--name"><%= link_to @message_user.name, @message_user %></span>
+          </div>
+          <div class="matching-show__messages-area" id="messages_area">
+            <%= render partial: 'messages/index', locals: { messages: @messages } %>
+          </div>
+          <div class="matching-show__message-form">
+            <%= render partial: 'messages/form', locals: { message: @message, room: @room } %>
+          </div>
+        </div>
       </div>
+      <%= render 'layouts/footer' %>
     </div>
   </div>
 </div>

--- a/app/views/users/_user_show_info.html.erb
+++ b/app/views/users/_user_show_info.html.erb
@@ -14,7 +14,7 @@
   <div class="user-show-info__introduction">
     <span class="user-show-info__introduction--title">自己紹介</span>
     <div class="user-show-info__introduction--content">
-      <%= simple_format(h(@user.introduction))%>
+      <%= simple_format(h(@user.introduction)) %>
     </div>
   </div>
   <div class="user-show-info__profile">


### PR DESCRIPTION
Closes #173 

### 【概要】
・メッセージ一覧ページのレイアウトを変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)