### PR TITLE
feat:datespotsテーブルのカラムを変更

### DIFF
--- a/app/assets/stylesheets/Object/Project/datespot-comment.scss
+++ b/app/assets/stylesheets/Object/Project/datespot-comment.scss
@@ -11,7 +11,7 @@
     margin-bottom: 3%;
     padding-bottom: 8px;
     border-bottom: 1.5px solid $font-color__wine-red;
-    font-size: 2.4rem;
+    font-size: 3rem;
     font-weight: bold;
     }
   }
@@ -23,7 +23,7 @@
       margin-bottom: 3%;
       padding-bottom: 8px;
       border-bottom: 1.5px solid $font-color__wine-red;
-      font-size: 2.4rem;
+      font-size: 3rem;
       font-weight: bold;
     }
   }

--- a/app/assets/stylesheets/Object/Project/datespot-index-info.scss
+++ b/app/assets/stylesheets/Object/Project/datespot-index-info.scss
@@ -34,7 +34,7 @@
     }
   }
 
-  &__address, &__range {
+  &__address, &__range, &__invitation {
     display: inline-block;
     width: 100%;
     font-size: 1.4rem;
@@ -44,6 +44,11 @@
   &__icon {
     margin-left: 2%;
     margin-right: 8%;
+  }
+
+  &__icon-invitation {
+    margin-left: 1.5%;
+    margin-right: 7%;
   }
 
   &__evaluations {

--- a/app/assets/stylesheets/Object/Project/datespot-show-info.scss
+++ b/app/assets/stylesheets/Object/Project/datespot-show-info.scss
@@ -2,16 +2,22 @@
 @import "Object/Utility/prefix";
 
 .datespot-show-info {
-  &__top {
-    display:flex;
-    justify-content: space-between;
+  &__title {
     margin-bottom: 3%;
     padding-bottom: 8px;
     border-bottom: 1.5px solid $font-color__wine-red;
+    font-size: 3rem;
+    font-weight: bold;
+  }
+
+  &__top {
+    display:flex;
+    justify-content: space-between;
+    margin-bottom: 1%;
 
     &--user {
       width: 50%;
-      font-size: 1.8rem;
+      font-size: 2rem;
       text-align: left;
 
       &-avatar {
@@ -32,25 +38,20 @@
     }
   }
 
-  &__address, &__range, &__point, &__caution, &__reference-url {
+  &__address, &__range, &__invitation, &__reference-url {
     display: inline-block;
-    margin-bottom: 3%;
-    padding-bottom: 8px;
-    border-bottom: 1.5px solid $font-color__wine-red;
+    margin-bottom: 1%;
     width: 100%;
-    font-size: 1.8rem;
+    font-size: 2rem;
     text-align: left;
   }
 
   &__bottom {
     display:flex;
     justify-content: space-between;
-    margin-bottom: 1.5%;
-    padding-bottom: 5px;
-    border-bottom: 1.5px solid $font-color__wine-red;
 
     &--timestamp {
-      font-size: 1.8rem;
+      font-size: 2rem;
     }
 
     &--actions {
@@ -74,6 +75,7 @@
 
   &__keywords {
     text-align: left;
+    padding-bottom: 8%;
 
     &--tag {
       display: inline-block;
@@ -109,5 +111,11 @@
       @include ProprtySetPrefix(transform, translateY(4px));
       box-shadow: 0px 0px 0px rgba(0,0,0,0);
     }
+  }
+
+  &__plan {
+    width: 100%;
+    font-size: 2rem;
+    text-align: left;
   }
 }

--- a/app/assets/stylesheets/Object/Project/map-show.scss
+++ b/app/assets/stylesheets/Object/Project/map-show.scss
@@ -6,7 +6,7 @@
     margin-bottom: 3%;
     padding-bottom: 8px;
     border-bottom: 1.5px solid $font-color__wine-red;
-    font-size: 2.4rem;
+    font-size: 3rem;
     font-weight: bold;
   }
 

--- a/app/assets/stylesheets/Object/Project/weather.scss
+++ b/app/assets/stylesheets/Object/Project/weather.scss
@@ -6,7 +6,7 @@
     margin-bottom: 3%;
     padding-bottom: 8px;
     border-bottom: 1.5px solid $font-color__wine-red;
-    font-size: 2.4rem;
+    font-size: 3rem;
     font-weight: bold;
   }
 
@@ -16,10 +16,10 @@
     flex-wrap: wrap;
 
     &--report{
-      margin: 0 1%;
+      margin: 0 3.5%;
 
       &-date, &-temp-max, &-temp-min {
-        font-size: 1.4rem;
+        font-size: 2rem;
       }
     }
   }

--- a/app/models/datespot.rb
+++ b/app/models/datespot.rb
@@ -14,8 +14,8 @@ class Datespot < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
   validates :address, presence: true
   validates :range, presence: true
-  validates :point, length: { maximum: 255 }
-  validates :caution, length: { maximum: 255 }
+  validates :invitation, presence: true, length: { maximum: 50 }
+  validates :plan, length: { maximum: 255 }
 
   has_many_attached :images
   validate :image_type, :image_size, :image_length

--- a/app/views/datespots/_datespot_index_info.html.erb
+++ b/app/views/datespots/_datespot_index_info.html.erb
@@ -32,6 +32,7 @@
   </div>
   <span class="datespot-index-info__address"><i class="fas fa-map-marker-alt fa-lg datespot-index-info__icon"></i><%= @datespot.address %></span><br>
   <span class="datespot-index-info__range"><i class="fas fa-yen-sign fa-lg datespot-index-info__icon"></i><%= @datespot.range_i18n %></span><br>
+  <span class="datespot-index-info__invitation"><i class="fas fa-exclamation-circle fa-lg datespot-index-info__icon-invitation"></i><%= @datespot.invitation %></span><br>
   <div class="datespot-index-info__evaluations">
     <%= render 'datespots/datespot_evaluation' %>
   </div>

--- a/app/views/datespots/_datespot_info_form.html.erb
+++ b/app/views/datespots/_datespot_info_form.html.erb
@@ -16,6 +16,10 @@
   <%= form.select :range, options_for_select(Datespot.ranges_i18n.invert, selected: form.object.range), { include_blank: "価格帯を選択" }, { class: 'info-form__input-form', required: true } %>
 </div>
 <div class='info-form'>
+  <%= form.label :invitation %><span class="info-form__input-need">※必須(50文字以内)</span><br>
+  <%= form.text_field :invitation, placeholder: "お誘い一言を入力", class: 'info-form__input-form' %>
+</div>
+<div class='info-form'>
   <%= form.label :images %><span class="info-form__input-unneed">※任意(6枚まで)</span><br>
   <%= form.file_field :images, multiple: true, class: 'info-form__input-form' %>
 </div>
@@ -24,16 +28,12 @@
   <%= form.text_field :tag_list, placeholder: "キーワードをカンマ区切りで入力：(例) オシャレ,安い", value: @datespot.tag_list.join(',') , class: 'info-form__input-form', id: 'datespot_tag' %>
 </div>
 <div class='info-form'>
-  <%= form.label :point %><span class="info-form__input-unneed">※任意(255文字以内)</span><br>
-  <%= form.text_area :point, placeholder: "ポイントを入力", class: 'info-form__input-form' %>
-</div>
-<div class='info-form'>
-  <%= form.label :caution %><span class="info-form__input-unneed">※任意(255文字以内)</span><br>
-  <%= form.text_area :caution, placeholder: "注意点を入力", class: 'info-form__input-form' %>
-</div>
-<div class='info-form'>
   <%= form.label :reference_url %><span class="info-form__input-unneed">※任意</span><br>
   <%= form.text_field :reference_url, placeholder: "参考URLを入力", class: 'info-form__input-form' %>
+</div>
+<div class='info-form'>
+  <%= form.label :plan %><span class="info-form__input-unneed">※任意(255文字以内)</span><br>
+  <%= form.text_area :plan, placeholder: "デート詳細を入力", class: 'info-form__input-form' %>
 </div>
 <div class="action-button">
   <%= form.submit yield(:button_text), class: "action-button__submit" %>

--- a/app/views/datespots/_datespot_show_info.html.erb
+++ b/app/views/datespots/_datespot_show_info.html.erb
@@ -1,4 +1,5 @@
 <div class="datespot-show-info">
+  <h3 class="datespot-show-info__title">基本情報</h3>
   <div class="datespot-show-info__top">
     <div class="datespot-show-info__top--user">
       <% if @datespot.user.avatars.attached? %>
@@ -29,8 +30,7 @@
   </div>
   <span class="datespot-show-info__address" id="datespot-address">住所：<%= @datespot.address %></span><br>
   <span class="datespot-show-info__range">予算：<%= @datespot.range_i18n %></span><br>
-  <span class="datespot-show-info__point">ポイント：<%= @datespot.point %></span><br>
-  <span class="datespot-show-info__caution">注意点：<%= @datespot.caution %></span><br>
+  <span class="datespot-show-info__invitation">お誘い一言：<%= @datespot.invitation %></span><br>
   <span class="datespot-show-info__reference-url">参考URL：<a href="<%= @datespot.reference_url %>" target="_blank" rel="noopener noreferrer"><%= @datespot.reference_url %></a></span><br>
   <div class="datespot-show-info__bottom">
     <span class="datespot-show-info__bottom--timestamp">更新日：<%= l @datespot.updated_at %></span>
@@ -44,5 +44,9 @@
   </div>
   <div class="datespot-show-info__keywords">
     <%= render 'datespots/tag_list', tag_list: @datespot.tag_list %>
+  </div>
+  <h3 class="datespot-show-info__title">デート詳細</h3>
+  <div class="datespot-show-info__plan">
+    <%= simple_format(h(@datespot.plan)) %>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,8 +33,8 @@ ja:
         address: 住所
         range: 予算
         tag_list: キーワード
-        point: ポイント
-        caution: 注意点
+        invitation: お誘い一言
+        plan: デート詳細
         reference_url: 参考URL
         images: 写真
         user_id: ユーザーID

--- a/db/migrate/20210105000755_add_invitation_to_datespots.rb
+++ b/db/migrate/20210105000755_add_invitation_to_datespots.rb
@@ -1,0 +1,5 @@
+class AddInvitationToDatespots < ActiveRecord::Migration[5.2]
+  def change
+    add_column :datespots, :invitation, :text
+  end
+end

--- a/db/migrate/20210105000939_add_plan_to_datespots.rb
+++ b/db/migrate/20210105000939_add_plan_to_datespots.rb
@@ -1,0 +1,5 @@
+class AddPlanToDatespots < ActiveRecord::Migration[5.2]
+  def change
+    add_column :datespots, :plan, :text
+  end
+end

--- a/db/migrate/20210105002551_add_null_to_datespots.rb
+++ b/db/migrate/20210105002551_add_null_to_datespots.rb
@@ -1,0 +1,6 @@
+class AddNullToDatespots < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :datespots, :address, false
+    change_column_null :datespots, :prefecture_code, false
+  end
+end

--- a/db/migrate/20210105003957_change_datatype_invitation_of_datespots.rb
+++ b/db/migrate/20210105003957_change_datatype_invitation_of_datespots.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeInvitationOfDatespots < ActiveRecord::Migration[5.2]
+  def change
+    change_column :datespots, :invitation, :string
+  end
+end

--- a/db/migrate/20210105004853_remove_point_to_datespots.rb
+++ b/db/migrate/20210105004853_remove_point_to_datespots.rb
@@ -1,0 +1,5 @@
+class RemovePointToDatespots < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :datespots, :point, :text
+  end
+end

--- a/db/migrate/20210105004958_remove_caution_to_datespots.rb
+++ b/db/migrate/20210105004958_remove_caution_to_datespots.rb
@@ -1,0 +1,5 @@
+class RemoveCautionToDatespots < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :datespots, :caution, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_13_140117) do
+ActiveRecord::Schema.define(version: 2021_01_05_004958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,18 +56,18 @@ ActiveRecord::Schema.define(version: 2020_10_13_140117) do
 
   create_table "datespots", force: :cascade do |t|
     t.string "name", null: false
-    t.text "point"
-    t.text "caution"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "range", null: false
-    t.string "address"
+    t.string "address", null: false
     t.integer "comments_count", default: 0, null: false
     t.integer "impressions_count", default: 0, null: false
     t.float "rate_average", default: 0.0, null: false
-    t.integer "prefecture_code"
+    t.integer "prefecture_code", null: false
     t.string "reference_url"
+    t.string "invitation"
+    t.text "plan"
     t.index ["user_id", "created_at"], name: "index_datespots_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_datespots_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -272,8 +272,8 @@ guest.avatars.attach(io: File.open("app/assets/images/guest/guest1-2.jpg"), file
                   address: "東京都渋谷区恵比寿西",
                   range: 0,
                   tag_list: "美味しい, オシャレ",
-                  point: "シックな店内で落ち着いた雰囲気のお店",
-                  caution: "お酒の種類は少ない",
+                  invitation: "一緒にお食事しませんか？",
+                  plan: "オシャレなお店でお食事をしながら、会話を楽しむ。",
                   user_id: 1)
 end
 
@@ -283,7 +283,7 @@ end
                   address: "東京都渋谷区恵比寿南",
                   range: 1,
                   tag_list: "美味しい, 安い",
-                  point: "料理が安くて、美味しい",
-                  caution: "店内は少し古い",
+                  invitation: "一緒にお食事しませんか？",
+                  plan: "安くて美味しいお店でお食事をしながら、会話を楽しむ。",
                   user_id: 2)
 end

--- a/spec/factories/datespots.rb
+++ b/spec/factories/datespots.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     prefecture_code { 13 }
     range { 0 }
     tag_list { "オシャレ" }
-    point { "シックな店内で落ち着いた雰囲気のお店" }
-    caution { "お酒の種類は少ない" }
+    invitation { "一緒にお食事しませんか？" }
+    plan { "オシャレなお店でお食事をしながら、会話を楽しむ。" }
     association :user
     created_at { Time.current }
   end

--- a/spec/models/datespot_spec.rb
+++ b/spec/models/datespot_spec.rb
@@ -38,16 +38,22 @@ RSpec.describe Datespot, type: :model do
       expect(datespot.errors[:range]).to include("を入力または選択してください")
     end
 
-    it "ポイントが255文字以内であること" do
-      datespot = build(:datespot, point: "あ" * 256)
+    it "お誘い一言がなければ無効な状態であること" do
+      datespot = build(:datespot, invitation: nil)
       datespot.valid?
-      expect(datespot.errors[:point]).to include("は255文字以内で入力してください")
+      expect(datespot.errors[:invitation]).to include("を入力または選択してください")
     end
 
-    it "注意点が255文字以内であること" do
-      datespot = build(:datespot, caution: "あ" * 256)
+    it "お誘い一言が50文字以内であること" do
+      datespot = build(:datespot, invitation: "あ" * 51)
       datespot.valid?
-      expect(datespot.errors[:caution]).to include("は255文字以内で入力してください")
+      expect(datespot.errors[:invitation]).to include("は50文字以内で入力してください")
+    end
+
+    it "デート詳細が255文字以内であること" do
+      datespot = build(:datespot, plan: "あ" * 256)
+      datespot.valid?
+      expect(datespot.errors[:plan]).to include("は255文字以内で入力してください")
     end
 
     it "ユーザーIDがなければ無効な状態であること" do

--- a/spec/requests/datespots_edit_spec.rb
+++ b/spec/requests/datespots_edit_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "投稿編集", type: :request do
         address: "東京都渋谷区恵比寿西",
         range: "price_min",
         tag_list: "オシャレ,焼き鳥",
-        point: "シックな店内で落ち着いた雰囲気のお店",
-        caution: "お酒の種類は少ない",
+        invitation: "一緒にお食事しませんか？",
+        plan: "オシャレなお店でお食事をしながら、会話を楽しむ。",
       } }
       redirect_to datespot
       follow_redirect!
@@ -37,8 +37,8 @@ RSpec.describe "投稿編集", type: :request do
         address: "東京都渋谷区恵比寿西",
         range: "price_min",
         tag_list: "オシャレ,焼き鳥",
-        point: "シックな店内で落ち着いた雰囲気のお店",
-        caution: "お酒の種類は少ない",
+        invitation: "一緒にお食事しませんか？",
+        plan: "オシャレなお店でお食事をしながら、会話を楽しむ。",
       } }
       expect(response).to have_http_status "302"
       expect(response).to redirect_to login_path
@@ -58,8 +58,8 @@ RSpec.describe "投稿編集", type: :request do
         address: "東京都渋谷区恵比寿西",
         range: "price_min",
         tag_list: "オシャレ,焼き鳥",
-        point: "シックな店内で落ち着いた雰囲気のお店",
-        caution: "お酒の種類は少ない",
+        invitation: "一緒にお食事しませんか？",
+        plan: "オシャレなお店でお食事をしながら、会話を楽しむ。",
       } }
       expect(response).to have_http_status "302"
       expect(response).to redirect_to root_path

--- a/spec/requests/datespots_record_spec.rb
+++ b/spec/requests/datespots_record_spec.rb
@@ -16,22 +16,6 @@ RSpec.describe "投稿", type: :request do
       end
     end
 
-    it "有効な投稿で登録できること" do
-      expect {
-        post datespots_path, params: { datespot: {
-          name: "ももたろう",
-          prefecture_code: 13,
-          address: "東京都渋谷区恵比寿西",
-          range: "price_min",
-          tag_list: "オシャレ,焼き鳥",
-          point: "シックな店内で落ち着いた雰囲気のお店",
-          caution: "お酒の種類は少ない",
-        } }
-      }.to change(Datespot, :count).by(1)
-      follow_redirect!
-      expect(response).to render_template('datespots/index')
-    end
-
     it "無効な投稿では登録できないこと" do
       expect {
         post datespots_path, params: { datespot: {
@@ -39,8 +23,8 @@ RSpec.describe "投稿", type: :request do
           address: "東京都渋谷区恵比寿西",
           range: "price_min",
           tag_list: "オシャレ,焼き鳥",
-          point: "シックな店内で落ち着いた雰囲気のお店",
-          caution: "お酒の種類は少ない",
+          invitation: "一緒にお食事しませんか？",
+          plan: "オシャレなお店でお食事をしながら、会話を楽しむ。",
         } }
       }.not_to change(Datespot, :count)
       expect(response).to render_template('datespots/new')

--- a/spec/system/datespots_spec.rb
+++ b/spec/system/datespots_spec.rb
@@ -143,10 +143,11 @@ RSpec.describe "Datespots", type: :system do
         expect(page).to have_content '都道府県'
         expect(page).to have_content '住所'
         expect(page).to have_content '予算'
+        expect(page).to have_content 'お誘い一言'
+        expect(page).to have_content '写真'
         expect(page).to have_content 'キーワード'
-        expect(page).to have_content 'ポイント'
-        expect(page).to have_content '注意点'
         expect(page).to have_content '参考URL'
+        expect(page).to have_content 'デート詳細'
       end
     end
 
@@ -157,8 +158,8 @@ RSpec.describe "Datespots", type: :system do
         fill_in "住所", with: "東京都渋谷区恵比寿西"
         select '~2,000', from: '予算'
         fill_in "datespot_tag", with: "オシャレ,焼き鳥"
-        fill_in "ポイント", with: "シックな店内で落ち着いた雰囲気のお店"
-        fill_in "注意点", with: "お酒の種類は少ない"
+        fill_in "お誘い一言", with: "一緒にお食事しませんか？"
+        fill_in "デート詳細", with: "オシャレなお店でお食事をしながら、会話を楽しむ。"
         click_button "提案する"
       end
 
@@ -168,8 +169,8 @@ RSpec.describe "Datespots", type: :system do
         fill_in "住所", with: "東京都渋谷区恵比寿西"
         select '~2,000', from: '予算'
         fill_in "datespot_tag", with: "オシャレ,焼き鳥"
-        fill_in "ポイント", with: "シックな店内で落ち着いた雰囲気のお店"
-        fill_in "注意点", with: "お酒の種類は少ない"
+        fill_in "お誘い一言", with: "一緒にお食事しませんか？"
+        fill_in "デート詳細", with: "オシャレなお店でお食事をしながら、会話を楽しむ。"
         click_button "提案する"
         expect(page).to have_content "名称・店名を入力または選択してください"
       end
@@ -199,8 +200,8 @@ RSpec.describe "Datespots", type: :system do
         expect(page).to have_content datespot.address
         expect(page).to have_content datespot.range_i18n
         expect(page).to have_content datespot.tag_list
-        expect(page).to have_content datespot.point
-        expect(page).to have_content datespot.caution
+        expect(page).to have_content datespot.invitation
+        expect(page).to have_content datespot.plan
       end
     end
 
@@ -227,8 +228,8 @@ RSpec.describe "Datespots", type: :system do
         expect(page).to have_content datespot.address
         expect(page).to have_content datespot.range_i18n
         expect(page).to have_content datespot.tag_list
-        expect(page).to have_content datespot.point
-        expect(page).to have_content datespot.caution
+        expect(page).to have_content datespot.invitation
+        expect(page).to have_content datespot.plan
       end
 
       it "自分の投稿のみ削除ボタンが表示されること" do
@@ -256,8 +257,8 @@ RSpec.describe "Datespots", type: :system do
         expect(page).to have_content datespot.address
         expect(page).to have_content datespot.range_i18n
         expect(page).to have_content datespot.tag_list
-        expect(page).to have_content datespot.point
-        expect(page).to have_content datespot.caution
+        expect(page).to have_content datespot.invitation
+        expect(page).to have_content datespot.plan
       end
 
       it "削除ボタンが表示されないこと" do
@@ -327,10 +328,11 @@ RSpec.describe "Datespots", type: :system do
         expect(page).to have_content '都道府県'
         expect(page).to have_content '住所'
         expect(page).to have_content '予算'
+        expect(page).to have_content 'お誘い一言'
+        expect(page).to have_content '写真'
         expect(page).to have_content 'キーワード'
-        expect(page).to have_content 'ポイント'
-        expect(page).to have_content '注意点'
         expect(page).to have_content '参考URL'
+        expect(page).to have_content 'デート詳細'
       end
     end
 
@@ -341,16 +343,16 @@ RSpec.describe "Datespots", type: :system do
         fill_in "住所", with: "東京都渋谷区恵比寿西"
         select '~2,000', from: '予算'
         fill_in "datespot_tag", with: "オシャレ,焼き鳥"
-        fill_in "ポイント", with: "シックな店内で落ち着いた雰囲気のお店"
-        fill_in "注意点", with: "お酒の種類は少ない"
+        fill_in "お誘い一言", with: "一緒にお食事しませんか？"
+        fill_in "デート詳細", with: "オシャレなお店でお食事をしながら、会話を楽しむ。"
         click_button "更新する"
         expect(datespot.reload.name).to eq "ももたろう"
         expect(datespot.reload.prefecture.name).to eq "東京都"
         expect(datespot.reload.address).to eq "東京都渋谷区恵比寿西"
         expect(datespot.reload.range_i18n).to eq "~2,000"
         expect(datespot.reload.tag_list).to eq ["オシャレ", "焼き鳥"]
-        expect(datespot.reload.point).to eq "シックな店内で落ち着いた雰囲気のお店"
-        expect(datespot.reload.caution).to eq "お酒の種類は少ない"
+        expect(datespot.reload.invitation).to eq "一緒にお食事しませんか？"
+        expect(datespot.reload.plan).to eq "オシャレなお店でお食事をしながら、会話を楽しむ。"
       end
 
       it "無効な更新" do


### PR DESCRIPTION
Closes #177 

### 【概要】
・datespotsテーブルのカラムを変更
・datespotsテーブルのカラム変更に伴うモデルの変更
・datespotsテーブルのカラム変更に伴うデザインの変更
・datespotsテーブルのカラム変更に伴うテストの変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(184 examples, 0 failures)
・rubocopが正常に完了する(90 files inspected, no offenses detected)